### PR TITLE
GitHub App認証IDのバリデーションを厳格化

### DIFF
--- a/app/services/github.server.ts
+++ b/app/services/github.server.ts
@@ -114,11 +114,18 @@ export async function createGitHubServiceFromEnv(): Promise<GitHubService> {
   const installationIdRaw = process.env.GITHUB_APP_INSTALLATION_ID ?? "";
   const privateKeyRaw = process.env.GITHUB_APP_PRIVATE_KEY ?? "";
 
-  const appId = Number(appIdRaw);
-  const installationId = Number(installationIdRaw);
+  const appId = Number.parseInt(appIdRaw, 10);
+  const installationId = Number.parseInt(installationIdRaw, 10);
   const privateKey = privateKeyRaw.replace(/\\n/g, "\n");
 
-  if (!Number.isFinite(appId) || !Number.isFinite(installationId) || !privateKey) {
+  const isValidAppAuth =
+    Number.isSafeInteger(appId) &&
+    appId > 0 &&
+    Number.isSafeInteger(installationId) &&
+    installationId > 0 &&
+    privateKey.length > 0;
+
+  if (!isValidAppAuth) {
     throw new Error(
       "GitHub認証情報が未設定です。GITHUB_TOKEN/GITHUB_PAT または GITHUB_APP_ID/GITHUB_APP_INSTALLATION_ID/GITHUB_APP_PRIVATE_KEY を設定してください",
     );


### PR DESCRIPTION
### Motivation
- 環境変数からの GitHub App 認証情報のパースで空文字などが数値に誤変換されると、後段の API 呼び出しで原因追跡しづらい失敗を起こすため、早期に不正設定を検出する必要がありました。

### Description
- `app/services/github.server.ts` の `createGitHubServiceFromEnv` を修正し、`GITHUB_APP_ID` と `GITHUB_APP_INSTALLATION_ID` を `Number.parseInt(..., 10)` でパースするように変更しました。  
- `appId` と `installationId` を `Number.isSafeInteger(...)` かつ `> 0` の正の安全整数であること、`privateKey` が空でないことを `isValidAppAuth` で明示的に検証するようにしました。  
- 公開 API の型や戻り値は変更しておらず、差分は認証情報のバリデーションに限定しています。

### Testing
- `npm run typecheck` を実行して型チェックが通ることを確認しました（`react-router typegen && tsc` が成功しました）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995bfefd5e083268bf00c8402ac1928)