### PR TITLE
Issue25-save-imagesPR本文のエビデンス画像保存対応と保存フローUX改善

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,42 @@
+
+################################################################################
+# repo-root/.codex/config.toml
+#
+# Project-scoped configuration.
+# Loaded only when you trust the project. (Config layering: see Config basics)
+################################################################################
+# NOTE: Profiles are experimental and NOT supported in the Codex IDE extension.
+# Use them from the CLI with: codex --profile <name>
+################################################################################
+
+# Keep defaults stable for IDE + browser usage.
+model = "gpt-5.2-codex"
+personality = "pragmatic"
+approval_policy = "on-request"
+model_reasoning_effort = "medium"
+
+# Optional: for CLI /review. Uses current session model unless overridden.
+# Set a stronger model if you want heavier review runs.
+# review_model = "gpt-5.2-codex"
+
+################################################################################
+# Profiles (CLI only)
+################################################################################
+
+[profiles.hq_coder]
+model = "gpt-5.2-codex"
+personality = "pragmatic"
+model_reasoning_effort = "medium"
+approval_policy = "on-request"
+
+[profiles.req_pl]
+model = "gpt-5.2-codex"
+personality = "pragmatic"
+model_reasoning_effort = "medium"
+approval_policy = "on-request"
+
+[profiles.test_qa]
+model = "gpt-5.2-codex"
+personality = "pragmatic"
+model_reasoning_effort = "high"
+approval_policy = "on-request"

--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,8 @@ SESSION_SECRET=
 # ONEDRIVE_OAUTH_REQUEST_TIMEOUT_MS=180
 # エビデンス画像1件あたりの最大ダウンロードサイズ（KB、任意。デフォルト: 10240 = 10MB）
 # ONEDRIVE_EVIDENCE_IMAGE_MAX_KB=10240
+# エビデンス画像の処理上限件数（任意。デフォルト: 20）
+# ONEDRIVE_EVIDENCE_IMAGE_MAX_COUNT=20
 # 旧設定（bytes）: ONEDRIVE_EVIDENCE_IMAGE_MAX_BYTES=10485760
 # エビデンス画像の許可ドメイン（カンマ区切り、任意）
 # 未設定時: github.com,user-images.githubusercontent.com,github-production-user-asset-6210df.s3.amazonaws.com

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ GITHUB_TOKEN=
 # GitHub App 認証（PATを使わない場合）
 # GITHUB_APP_ID=
 # GITHUB_APP_INSTALLATION_ID=
+# GitHub APIリクエストのタイムアウト（秒、任意。デフォルト: 180）
+# GITHUB_REQUEST_TIMEOUT_MS=180
 # GITHUB_APP_PRIVATE_KEY の設定方法:
 # - .env ファイルに直接書く場合は、PEM 形式の秘密鍵をそのまま複数行で貼り付ける（引用符は付けない）
 #   例:
@@ -47,6 +49,8 @@ SESSION_SECRET=
 # 任意: リバースプロキシから渡す共有シークレット
 # 設定時は x-onedrive-proxy-secret ヘッダーが一致する場合のみ X-Forwarded-* を信頼
 # ONEDRIVE_TRUST_PROXY_SHARED_SECRET=
+# OAuthトークン交換リクエストのタイムアウト（秒、任意。デフォルト: 180）
+# ONEDRIVE_OAUTH_REQUEST_TIMEOUT_MS=180
 # 保存先フォルダ（OneDriveのルート配下）
 # ONEDRIVE_BASE_FOLDER="pr-description-collector"
 

--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,9 @@ SESSION_SECRET=
 # ONEDRIVE_TRUST_PROXY_SHARED_SECRET=
 # OAuthトークン交換リクエストのタイムアウト（秒、任意。デフォルト: 180）
 # ONEDRIVE_OAUTH_REQUEST_TIMEOUT_MS=180
+# エビデンス画像1件あたりの最大ダウンロードサイズ（KB、任意。デフォルト: 10240 = 10MB）
+# ONEDRIVE_EVIDENCE_IMAGE_MAX_KB=10240
+# 旧設定（bytes）: ONEDRIVE_EVIDENCE_IMAGE_MAX_BYTES=10485760
 # 保存先フォルダ（OneDriveのルート配下）
 # ONEDRIVE_BASE_FOLDER="pr-description-collector"
 

--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,6 @@ GITHUB_TOKEN=
 # GITHUB_APP_INSTALLATION_ID=
 # GitHub APIリクエストのタイムアウト（秒、任意。デフォルト: 180）
 # GITHUB_REQUEST_TIMEOUT_SECONDS=180
-# 旧キー（後方互換・秒として解釈）:
-# GITHUB_REQUEST_TIMEOUT_MS=180
 # GITHUB_APP_PRIVATE_KEY の設定方法:
 # - .env ファイルに直接書く場合は、PEM 形式の秘密鍵をそのまま複数行で貼り付ける（引用符は付けない）
 #   例:
@@ -52,8 +50,9 @@ SESSION_SECRET=
 # 設定時は x-onedrive-proxy-secret ヘッダーが一致する場合のみ X-Forwarded-* を信頼
 # ONEDRIVE_TRUST_PROXY_SHARED_SECRET=
 # OAuthトークン交換リクエストのタイムアウト（秒、任意。デフォルト: 180）
-# ONEDRIVE_OAUTH_REQUEST_TIMEOUT_MS=180
+# ONEDRIVE_OAUTH_REQUEST_TIMEOUT_SECONDS=180
 # エビデンス画像1件あたりの最大ダウンロードサイズ（KB、任意。デフォルト: 10240 = 10MB）
+# Microsoft Graph 単純アップロード上限（250MB）を超える値は 250MB に丸められます。
 # ONEDRIVE_EVIDENCE_IMAGE_MAX_KB=10240
 # エビデンス画像の処理上限件数（任意。デフォルト: 20）
 # ONEDRIVE_EVIDENCE_IMAGE_MAX_COUNT=20

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ GITHUB_TOKEN=
 # GITHUB_APP_ID=
 # GITHUB_APP_INSTALLATION_ID=
 # GitHub APIリクエストのタイムアウト（秒、任意。デフォルト: 180）
+# GITHUB_REQUEST_TIMEOUT_SECONDS=180
+# 旧キー（後方互換・秒として解釈）:
 # GITHUB_REQUEST_TIMEOUT_MS=180
 # GITHUB_APP_PRIVATE_KEY の設定方法:
 # - .env ファイルに直接書く場合は、PEM 形式の秘密鍵をそのまま複数行で貼り付ける（引用符は付けない）

--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,9 @@ SESSION_SECRET=
 # エビデンス画像1件あたりの最大ダウンロードサイズ（KB、任意。デフォルト: 10240 = 10MB）
 # ONEDRIVE_EVIDENCE_IMAGE_MAX_KB=10240
 # 旧設定（bytes）: ONEDRIVE_EVIDENCE_IMAGE_MAX_BYTES=10485760
+# エビデンス画像の許可ドメイン（カンマ区切り、任意）
+# 未設定時: github.com,user-images.githubusercontent.com,github-production-user-asset-6210df.s3.amazonaws.com
+# ONEDRIVE_EVIDENCE_IMAGE_ALLOWED_HOSTS=github.com,user-images.githubusercontent.com
 # 保存先フォルダ（OneDriveのルート配下）
 # ONEDRIVE_BASE_FOLDER="pr-description-collector"
 

--- a/.github/ISSUE_TEMPLATE/02_bug.md
+++ b/.github/ISSUE_TEMPLATE/02_bug.md
@@ -1,0 +1,52 @@
+---
+name: "Bug (AI-ready)"
+about: "再現手順・期待挙動・実挙動・影響範囲を明確にする"
+title: "[Bug] "
+labels: ["bug"]
+assignees: []
+---
+
+## 事象（What）
+- 何が起きているか（簡潔に）
+
+## 期待される挙動（Expected）
+- 本来どうあるべきか
+
+## 実際の挙動（Actual）
+- 実際どうなっているか
+
+## 影響範囲（Impact）
+- ユーザー影響:
+- データ影響:
+- 頻度:
+- 緊急度:
+
+## 再現手順（Repro Steps）
+1. 
+2. 
+3. 
+
+## 環境（Environment）
+- OS / Browser / Runtime:
+- Version（アプリ/依存）:
+- Feature flag / Config:
+
+## ログ・スクショ・エラー（Evidence）
+- ログ:
+- スタックトレース:
+- 画面/動画:
+- 関連PR/Issue:
+
+## 原因仮説（Hypothesis）
+- （分かれば）あり得る原因
+- 分からなければ「不明」でOK
+
+## 対応方針（Fix Plan）
+- 最小修正案:
+- リスク:
+- 追加テスト案:
+
+## 検証（Verification）
+- 修正後の確認手順:
+- 追加/更新するテスト:
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ Definition of Done (minimum):
   - Commands run (exact commands), OR
   - NOT RUN + reason + manual verification steps.
 - Any new/changed public contract is locked (tests or explicit invariants).
+- If boundary/failure-mode triggers are present, failure-mode & trust-boundary coverage is reported.
 
 Validation Commands Slot:
 - [HQ|VSCODE] MUST propose the repo-specific validation commands once the stack is inferred.
@@ -149,6 +150,28 @@ When touching any high-risk area:
   👉 STOP and ask ONE question as [ReqPL].
 
 ############################################################
+# Failure-Mode & Trust-Boundary Review Gate (CRITICAL)
+############################################################
+
+Boundary/failure-mode triggers:
+- external integrations (OneDrive, payments, etc.)
+- public API endpoints (/api/*)
+- background jobs / async workflows
+- user-facing async UI with side effects (save/submit/upload)
+
+When any trigger is present:
+- [ReqPL] MUST specify failure behavior for:
+  - validation errors, auth failure (401/403), timeout/network failure, rate limit (429), server error (5xx)
+  - side effects: what must NOT happen on failure (no partial save, no duplicate submit, etc.)
+  - retry policy / user messaging (if applicable)
+- [HQ] MUST implement:
+  - explicit error handling (no silent failure)
+  - idempotency/duplicate prevention for side-effecting operations (if applicable)
+- [QA] MUST produce (keep it compact):
+  - Trust-boundary checklist (<=6 bullets): authn/authz, input validation, PII/logging, external calls
+  - Failure-mode matrix (<=8 rows): failure → expected behavior → evidence (test/log/screenshot)
+
+############################################################
 # Language
 ############################################################
 
@@ -175,44 +198,6 @@ If TECH_STACK_JP is empty:
 """
 
 ---
-
-############################################################
-# File Header Comment Policy (optional, configurable)
-############################################################
-
-FILE_HEADER_COMMENT_MODE = "new_and_boundary"
-# Allowed:
-# - "off"             : do not emit file header comments
-# - "new_only"        : only for newly created files
-# - "new_and_boundary": new files + boundary/high-risk areas only (default)
-# - "always"          : always emit (discouraged)
-
-HEADER_COMMENT_TRIGGERS = """
-Emit a file header comment when:
-- New file is created, AND
-- One of:
-  - boundary layer (api route/controller/service adapter)
-  - external integration (OneDrive, payments, auth)
-  - user-facing UI component with async/side effects
-  - high-risk area (db/auth/deps/build/secrets)
-Otherwise: no header comment.
-"""
-
-HEADER_COMMENT_TEMPLATE_JP = """
-/*
-  <概要: 1行>
-
-  このファイルを用意した理由:
-  - <理由1>
-  - <理由2>
-
-  このファイルが使われる場面:
-  - <entry point / feature / route / job> のとき
-
-  関連:
-  - <PR/Issue/ADR>（任意）
-*/
-"""
 
 ############################################################
 # Core Priorities
@@ -281,7 +266,7 @@ Validated progress > theoretical perfection.
 - Non-goals:
 - Constraints / Invariants:
 - Acceptance (Must/Should/Could):
-- Failure behavior:
+- Failure behavior (error/status/user message/side effects/retry):
 - Success signal (how to verify):
 - ONE question (only if ambiguity blocks correctness):
 
@@ -296,7 +281,8 @@ Validated progress > theoretical perfection.
 ### [QA] Template
 - Contracts changed / locked:
 - Minimal tests (high-signal only):
-- Error-path coverage:
+- Security / Trust boundary coverage (authn/authz/input/PII/logs) [if applicable]:
+- Failure-mode coverage (timeouts/401/403/429/5xx/partial/idempotency/retry):
 - Flake check (time/random/external):
 - Stop condition (why this is enough):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,44 @@ If TECH_STACK_JP is empty:
 ---
 
 ############################################################
+# File Header Comment Policy (optional, configurable)
+############################################################
+
+FILE_HEADER_COMMENT_MODE = "new_and_boundary"
+# Allowed:
+# - "off"             : do not emit file header comments
+# - "new_only"        : only for newly created files
+# - "new_and_boundary": new files + boundary/high-risk areas only (default)
+# - "always"          : always emit (discouraged)
+
+HEADER_COMMENT_TRIGGERS = """
+Emit a file header comment when:
+- New file is created, AND
+- One of:
+  - boundary layer (api route/controller/service adapter)
+  - external integration (OneDrive, payments, auth)
+  - user-facing UI component with async/side effects
+  - high-risk area (db/auth/deps/build/secrets)
+Otherwise: no header comment.
+"""
+
+HEADER_COMMENT_TEMPLATE_JP = """
+/*
+  <概要: 1行>
+
+  このファイルを用意した理由:
+  - <理由1>
+  - <理由2>
+
+  このファイルが使われる場面:
+  - <entry point / feature / route / job> のとき
+
+  関連:
+  - <PR/Issue/ADR>（任意）
+*/
+"""
+
+############################################################
 # Core Priorities
 ############################################################
 

--- a/CHECKLIST_TEMPLATE.md
+++ b/CHECKLIST_TEMPLATE.md
@@ -26,8 +26,9 @@
 ## 使い方ルール
 - `CHK-xx` は PR 全体で連番にする（Scope をまたいでも番号を振り直さない）
 - `Result` は「確認した事実」を1文で書く
-- `Evidence` は画像URL、PRコメントURL、ファイル名のいずれかを必ず入れる
-- 非該当は `Evidence: N/A` ではなく、`Result` に `N/A: 理由` を書く
+- `Evidence` は画像URL、PRコメントURL、ファイル名を基本とし、未達/非スコープは `N/A` を使う
+- 未達は `Result` に未達理由や次タスクを記載し、`Evidence: N/A` にする
+- Out of Scope は `Result: 非スコープ`、`Evidence: N/A` にする
 
 ## 人間レビュー対応（最後に追記）
 - 人間レビュー（スタッフ/シニア/レビュアー）完了後、以下のセクションをチェックリストの末尾へ追記する
@@ -42,6 +43,3 @@
   Evidence:
 
 ### Scope: Out of Scope（Human Review）
-- [ ] PR本文中画像の取得・`evidence-img/` 保存は未実装である
-  Result: 本PRで未対応であることを明記し、追跡Issueと紐づける
-  Evidence:

--- a/app/components/SaveErrorDialog.test.ts
+++ b/app/components/SaveErrorDialog.test.ts
@@ -16,7 +16,7 @@ describe("formatPartialWriteErrorMessage", () => {
       "OneDrive API error (500): write failed | partial-write: description.md saved then archive.json failed; rollback=failed (permission denied)",
     );
     expect(message).toBe(
-      "保存に失敗しました。再試行してください。解決しない場合は管理者にお問い合わせください。",
+      "保存中にエラーが発生したため、画像保存を取り消しました。再認証または時間をおいて再実行してください。",
     );
   });
 

--- a/app/components/SaveErrorDialog.test.ts
+++ b/app/components/SaveErrorDialog.test.ts
@@ -16,7 +16,7 @@ describe("formatPartialWriteErrorMessage", () => {
       "OneDrive API error (500): write failed | partial-write: description.md saved then archive.json failed; rollback=failed (permission denied)",
     );
     expect(message).toBe(
-      "保存中にエラーが発生したため、画像保存を取り消しました。再認証または時間をおいて再実行してください。",
+      "保存中にエラーが発生しました。一部のファイルが保存されたまま残っている可能性があります。再実行する前に OneDrive 上の保存先フォルダーを確認し、重複や不要なファイルを整理してください。解決しない場合は、再認証または時間をおいて再実行してください。",
     );
   });
 

--- a/app/components/SaveErrorDialog.tsx
+++ b/app/components/SaveErrorDialog.tsx
@@ -7,7 +7,7 @@ import { useEffect, useRef } from "react";
 export function formatPartialWriteErrorMessage(error: string): string | null {
   if (!error.includes("partial-write:")) return null;
   // セキュリティ上の理由で、内部処理状態や詳細理由はUIに表示しない。
-  return "保存中にエラーが発生したため、画像保存を取り消しました。再認証または時間をおいて再実行してください。";
+  return "保存中にエラーが発生しました。一部のファイルが保存されたまま残っている可能性があります。再実行する前に OneDrive 上の保存先フォルダーを確認し、重複や不要なファイルを整理してください。解決しない場合は、再認証または時間をおいて再実行してください。";
 }
 
 // 保存エラーダイアログのプロパティ

--- a/app/components/SaveErrorDialog.tsx
+++ b/app/components/SaveErrorDialog.tsx
@@ -7,7 +7,7 @@ import { useEffect, useRef } from "react";
 export function formatPartialWriteErrorMessage(error: string): string | null {
   if (!error.includes("partial-write:")) return null;
   // セキュリティ上の理由で、内部処理状態や詳細理由はUIに表示しない。
-  return "保存に失敗しました。再試行してください。解決しない場合は管理者にお問い合わせください。";
+  return "保存中にエラーが発生したため、画像保存を取り消しました。再認証または時間をおいて再実行してください。";
 }
 
 // 保存エラーダイアログのプロパティ

--- a/app/components/SavingDialog.tsx
+++ b/app/components/SavingDialog.tsx
@@ -1,0 +1,45 @@
+/*
+  保存中ダイアログコンポーネント
+
+  このファイルを用意した理由:
+  - OneDrive 保存に時間がかかる間、処理中であることを明示して誤操作や再送信を防ぐため。
+
+  このファイルが使われる場面:
+  - `/api/onedrive/upload` 実行中に、画面上で保存処理の進行中表示を出すとき。
+*/
+
+import { useEffect, useRef } from "react";
+
+type SavingDialogProps = {
+  open: boolean;
+};
+
+export function SavingDialog({ open }: SavingDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+
+  useEffect(() => {
+    if (!dialogRef.current) return;
+    if (open && !dialogRef.current.open) {
+      dialogRef.current.showModal();
+    } else if (!open && dialogRef.current.open) {
+      dialogRef.current.close();
+    }
+  }, [open]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="dialog"
+      aria-labelledby="saving-dialog-title"
+    >
+      <div className="dialog-card">
+        <h2 id="saving-dialog-title" className="dialog-title">
+          保存中です
+        </h2>
+        <p className="dialog-text">
+          OneDrive へ保存しています。画像件数によっては時間がかかることがあります。
+        </p>
+      </div>
+    </dialog>
+  );
+}

--- a/app/components/SuccessDialog.test.ts
+++ b/app/components/SuccessDialog.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatEvidenceImagesMessage } from "./SuccessDialog";
+
+describe("formatEvidenceImagesMessage", () => {
+  it("画像対象が0件なら対象なしメッセージを返す", () => {
+    expect(formatEvidenceImagesMessage({ total: 0, success: 0, failed: 0 })).toBe(
+      "画像は対象が0件でした。",
+    );
+  });
+
+  it("全失敗なら保存できなかったメッセージを返す", () => {
+    expect(formatEvidenceImagesMessage({ total: 16, success: 0, failed: 16 })).toBe(
+      "画像は保存できませんでした（成功: 0件 / 失敗: 16件）。",
+    );
+  });
+
+  it("一部または全件成功なら従来メッセージを返す", () => {
+    expect(formatEvidenceImagesMessage({ total: 3, success: 2, failed: 1 })).toBe(
+      "画像を保存しました（成功: 2件 / 失敗: 1件）。",
+    );
+  });
+});

--- a/app/components/SuccessDialog.tsx
+++ b/app/components/SuccessDialog.tsx
@@ -11,6 +11,22 @@ type SuccessDialogProps = {
   } | null;
 };
 
+// 画像保存の結果をユーザーフレンドリーなメッセージに変換するユーティリティ関数
+export function formatEvidenceImagesMessage(evidenceImages: {
+  total: number;
+  success: number;
+  failed: number;
+}): string {
+  if (evidenceImages.total === 0) {
+    return "画像は対象が0件でした。";
+  }
+  if (evidenceImages.success === 0 && evidenceImages.failed > 0) {
+    return `画像は保存できませんでした（成功: ${evidenceImages.success}件 / 失敗: ${evidenceImages.failed}件）。`;
+  }
+  return `画像を保存しました（成功: ${evidenceImages.success}件 / 失敗: ${evidenceImages.failed}件）。`;
+}
+
+// PR説明とエビデンス画像の保存成功を知らせるダイアログコンポーネント
 export function SuccessDialog({ open, onClose, evidenceImages }: SuccessDialogProps) {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
 
@@ -37,13 +53,7 @@ export function SuccessDialog({ open, onClose, evidenceImages }: SuccessDialogPr
         </h2>
         <p className="dialog-text">description.md と archive.json を保存しました。</p>
         {evidenceImages ? (
-          evidenceImages.total === 0 ? (
-            <p className="dialog-text">画像は対象が0件でした。</p>
-          ) : (
-            <p className="dialog-text">
-              画像を保存しました（成功: {evidenceImages.success}件 / 失敗: {evidenceImages.failed}件）。
-            </p>
-          )
+          <p className="dialog-text">{formatEvidenceImagesMessage(evidenceImages)}</p>
         ) : null}
         <div className="dialog-actions">
           <button type="button" className="btn secondary" onClick={onClose}>

--- a/app/components/SuccessDialog.tsx
+++ b/app/components/SuccessDialog.tsx
@@ -4,9 +4,14 @@ import { useEffect, useRef } from "react";
 type SuccessDialogProps = {
   open: boolean;
   onClose: () => void;
+  evidenceImages?: {
+    total: number;
+    success: number;
+    failed: number;
+  } | null;
 };
 
-export function SuccessDialog({ open, onClose }: SuccessDialogProps) {
+export function SuccessDialog({ open, onClose, evidenceImages }: SuccessDialogProps) {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
 
   // ダイアログの開閉制御
@@ -31,6 +36,15 @@ export function SuccessDialog({ open, onClose }: SuccessDialogProps) {
           保存が完了しました
         </h2>
         <p className="dialog-text">description.md と archive.json を保存しました。</p>
+        {evidenceImages ? (
+          evidenceImages.total === 0 ? (
+            <p className="dialog-text">画像は対象が0件でした。</p>
+          ) : (
+            <p className="dialog-text">
+              画像を保存しました（成功: {evidenceImages.success}件 / 失敗: {evidenceImages.failed}件）。
+            </p>
+          )
+        ) : null}
         <div className="dialog-actions">
           <button type="button" className="btn secondary" onClick={onClose}>
             Close

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,6 +1,6 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { Form, useActionData, useFetcher, useLoaderData, useSearchParams } from "react-router";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import MarkdownIt from "markdown-it";
 import taskLists from "markdown-it-task-lists";
 import { parseChecklist, summarize, type Checklist } from "../services/checklist";
@@ -37,6 +37,16 @@ type ActionData =
   | { ok: true; description: string; result: Checklist }
   | { ok: false; error: string };
 type LoaderData = { csrfToken: string };
+
+const FETCHER_TRANSPORT_ERROR_KEY = "fetcher-transport-error";
+const FETCHER_TRANSPORT_ERROR_MESSAGE =
+  "サーバーエラーが発生しました。トップページに戻りました。しばらくしてから再実行してください。";
+const OAUTH_CALLBACK_ERROR_MESSAGE =
+  "OneDrive 認証に失敗しました。Connect OneDrive から再試行してください。";
+
+function isFetcherApiResponse(value: unknown): value is { ok: boolean } {
+  return typeof value === "object" && value !== null && typeof (value as { ok?: unknown }).ok === "boolean";
+}
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const { token, setCookie } = await ensureCsrfToken(request);
@@ -196,10 +206,30 @@ export default function Index() {
 
   const [searchParams, setSearchParams] = useSearchParams();
   const onedriveConnected = searchParams.get("onedrive") === "connected";
+  const onedriveOAuthFailed = searchParams.get("onedrive") === "oauth_failed";
   const [isCheckingOneDriveSession, setIsCheckingOneDriveSession] = useState(false);
   const [isAuthDialogOpen, setIsAuthDialogOpen] = useState(false);
   const [isErrorDialogOpen, setIsErrorDialogOpen] = useState(false);
   const [isSuccessDialogOpen, setIsSuccessDialogOpen] = useState(false);
+  const [transportError, setTransportError] = useState<string | null>(null);
+  const collectRequestStartedRef = useRef(false);
+  const uploadRequestStartedRef = useRef(false);
+  const sessionStatusRequestStartedRef = useRef(false);
+
+  const redirectToTopOnTransportError = () => {
+    if (typeof window === "undefined") return;
+    window.sessionStorage.setItem(FETCHER_TRANSPORT_ERROR_KEY, FETCHER_TRANSPORT_ERROR_MESSAGE);
+    window.location.assign("/");
+  };
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const persistedError = window.sessionStorage.getItem(FETCHER_TRANSPORT_ERROR_KEY);
+    if (!persistedError) return;
+    setTransportError(persistedError);
+    window.sessionStorage.removeItem(FETCHER_TRANSPORT_ERROR_KEY);
+  }, []);
+
   const effectiveError = (uploadError && uploadError !== INVALID_PR_REF_ERROR ? uploadError : null) ?? sessionStatusError;
   const isAuthError =
     (uploadFetcher.data && !uploadFetcher.data.ok && uploadFetcher.data.isAuthError) ||
@@ -208,9 +238,14 @@ export default function Index() {
       sessionStatusFetcher.data.isAuthError) ||
     false;
 
+  // 画面上のエラー表示は、APIからのエラーと通信エラーで分ける。
   useEffect(() => {
     if (effectiveError) setIsErrorDialogOpen(true);
   }, [effectiveError]);
+  // APIからのエラーは画面上の注釈で表示するため、APIエラーがある場合はエラー表示用ダイアログは開かないようにする。
+  useEffect(() => {
+    if (transportError) setIsErrorDialogOpen(true);
+  }, [transportError]);
 
   useEffect(() => {
     if (collectError) {
@@ -233,6 +268,42 @@ export default function Index() {
   }, [uploadFetcher.data]);
 
   useEffect(() => {
+    if (collectFetcher.state !== "idle") {
+      collectRequestStartedRef.current = true;
+      return;
+    }
+    if (!collectRequestStartedRef.current) return;
+    collectRequestStartedRef.current = false;
+    if (!isFetcherApiResponse(collectFetcher.data)) {
+      redirectToTopOnTransportError();
+    }
+  }, [collectFetcher.state, collectFetcher.data]);
+
+  useEffect(() => {
+    if (uploadFetcher.state !== "idle") {
+      uploadRequestStartedRef.current = true;
+      return;
+    }
+    if (!uploadRequestStartedRef.current) return;
+    uploadRequestStartedRef.current = false;
+    if (!isFetcherApiResponse(uploadFetcher.data)) {
+      redirectToTopOnTransportError();
+    }
+  }, [uploadFetcher.state, uploadFetcher.data]);
+
+  useEffect(() => {
+    if (sessionStatusFetcher.state !== "idle") {
+      sessionStatusRequestStartedRef.current = true;
+      return;
+    }
+    if (!sessionStatusRequestStartedRef.current) return;
+    sessionStatusRequestStartedRef.current = false;
+    if (!isFetcherApiResponse(sessionStatusFetcher.data)) {
+      redirectToTopOnTransportError();
+    }
+  }, [sessionStatusFetcher.state, sessionStatusFetcher.data]);
+
+  useEffect(() => {
     if (collectFetcher.state !== "idle") return;
     if (collectFetcher.data?.ok && pendingCollectRef) {
       setLastCollectedRef(pendingCollectRef);
@@ -250,6 +321,14 @@ export default function Index() {
     next.delete("onedrive");
     setSearchParams(next, { replace: true });
   }, [onedriveConnected, searchParams, setSearchParams, sessionStatusFetcher]);
+
+  useEffect(() => {
+    if (!onedriveOAuthFailed) return;
+    setTransportError(OAUTH_CALLBACK_ERROR_MESSAGE);
+    const next = new URLSearchParams(searchParams);
+    next.delete("onedrive");
+    setSearchParams(next, { replace: true });
+  }, [onedriveOAuthFailed, searchParams, setSearchParams]);
 
   useEffect(() => {
     if (isCheckingOneDriveSession && sessionStatusFetcher.data?.ok) {
@@ -491,8 +570,11 @@ export default function Index() {
       />
       <SaveErrorDialog
         open={isErrorDialogOpen}
-        onClose={() => setIsErrorDialogOpen(false)}
-        error={effectiveError ?? ""}
+        onClose={() => {
+          setIsErrorDialogOpen(false);
+          setTransportError(null);
+        }}
+        error={transportError ?? effectiveError ?? ""}
         isAuthError={isAuthError}
       />
       <SuccessDialog

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -287,7 +287,7 @@ export default function Index() {
         <h2>Fetch from GitHub</h2>
         <div className="annotation-wrapper" aria-live="polite">
           {!collectFetcher.data?.ok ? (
-            <p className="annotation-text">Get Description を押してから保存してください。</p>
+            <p className="annotation-text">Get Description は取得のみです。保存（画像含む）は Save to OneDrive で実行します。</p>
           ) : null}
           {showPrRefAnnotation ? (
             <p className="annotation-text-small">
@@ -366,7 +366,7 @@ export default function Index() {
                 !prRefValidation.ok
               }
             >
-              Get Description
+              Get Description (Fetch Only)
             </button>
             <a className="btn connect-one-drive-btn" href="/auth/onedrive/login">
               Connect OneDrive
@@ -394,7 +394,7 @@ export default function Index() {
                 !isSaveTargetInSync
               }
             >
-              Save to OneDrive
+              Save to OneDrive (with images)
             </button>
 
             <Form method="post" className="form">
@@ -494,6 +494,7 @@ export default function Index() {
       <SuccessDialog
         open={isSuccessDialogOpen}
         onClose={() => setIsSuccessDialogOpen(false)}
+        evidenceImages={uploadFetcher.data?.ok ? uploadFetcher.data.evidenceImages : null}
       />
     </main>
   );

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import { ensureCsrfToken, verifyCsrfToken } from "../services/csrf.server";
 
 import { OneDriveAuthDialog } from "../components/OneDriveAuthDialog";
 import { SaveErrorDialog } from "../components/SaveErrorDialog";
+import { SavingDialog } from "../components/SavingDialog";
 import { SuccessDialog } from "../components/SuccessDialog";
 
 /**
@@ -484,6 +485,9 @@ export default function Index() {
       <OneDriveAuthDialog
         open={isAuthDialogOpen}
         onClose={() => setIsAuthDialogOpen(false)}
+      />
+      <SavingDialog
+        open={uploadFetcher.state !== "idle"}
       />
       <SaveErrorDialog
         open={isErrorDialogOpen}

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -15,6 +15,12 @@ import { createOneDriveServiceFromEnv } from "../services/onedrive.server";
 import { parseChecklist } from "../services/checklist";
 import { verifyCsrfToken } from "../services/csrf.server";
 import { validatePrRefInput } from "../services/validation";
+// 画像保存ユーティリティ
+import {
+  buildImageBaseName,
+  downloadImageWithRetry,
+  extractUniqueImageUrls,
+} from "../services/evidence-images.server";
 
 vi.mock("../services/github.server", () => ({
   createGitHubServiceFromEnv: vi.fn(),
@@ -36,6 +42,12 @@ vi.mock("../services/validation", () => ({
   validatePrRefInput: vi.fn(),
 }));
 
+vi.mock("../services/evidence-images.server", () => ({
+  extractUniqueImageUrls: vi.fn(),
+  downloadImageWithRetry: vi.fn(),
+  buildImageBaseName: vi.fn(),
+}));
+
 type MockGitHubService = {
   getPullRequest: ReturnType<typeof vi.fn>;
   getPullRequestReviews: ReturnType<typeof vi.fn>;
@@ -45,6 +57,8 @@ type MockOneDriveService = {
   getDriveInfo: ReturnType<typeof vi.fn>;
   getCurrentUser: ReturnType<typeof vi.fn>;
   saveText: ReturnType<typeof vi.fn>;
+  saveBinary: ReturnType<typeof vi.fn>;
+  getItem: ReturnType<typeof vi.fn>;
   deleteItem: ReturnType<typeof vi.fn>;
 };
 
@@ -71,6 +85,12 @@ describe("api.onedrive.upload action", () => {
     });
     vi.mocked(verifyCsrfToken).mockResolvedValue(true);
     vi.mocked(parseChecklist).mockReturnValue({ items: [], checked: 0, total: 0 });
+    vi.mocked(extractUniqueImageUrls).mockReturnValue([]);
+    vi.mocked(buildImageBaseName).mockReturnValue("image.png");
+    vi.mocked(downloadImageWithRetry).mockResolvedValue({
+      bytes: new Uint8Array([1, 2, 3]),
+      contentType: "image/png",
+    });
 
     github = {
       getPullRequest: vi.fn().mockResolvedValue({
@@ -93,6 +113,8 @@ describe("api.onedrive.upload action", () => {
         userPrincipalName: "user@example.com",
       }),
       saveText: vi.fn(),
+      saveBinary: vi.fn().mockResolvedValue({ name: "image.png", webUrl: "https://example.com/image.png" }),
+      getItem: vi.fn().mockResolvedValue(null),
       deleteItem: vi.fn(),
     };
     vi.mocked(createOneDriveServiceFromEnv).mockResolvedValue(onedrive as never);
@@ -224,6 +246,11 @@ describe("api.onedrive.upload action", () => {
     const body = (await response.json()) as {
       ok: true;
       folderPath: string;
+      evidenceImages: {
+        total: number;
+        success: number;
+        failed: number;
+      };
       uploaded: {
         descriptionMd: { name: string; webUrl: string };
         archiveJson: { name: string; webUrl: string };
@@ -241,7 +268,101 @@ describe("api.onedrive.upload action", () => {
       name: "archive.json",
       webUrl: "https://example.com/archive",
     });
+    expect(body.evidenceImages).toEqual({
+      total: 0,
+      success: 0,
+      failed: 0,
+    });
     expect(onedrive.saveText).toHaveBeenCalledTimes(2);
+  });
+
+  it("画像URLが重複しても1回だけ保存し evidenceImages に1件記録する", async () => {
+    github.getPullRequest.mockResolvedValueOnce({
+      number: 123,
+      title: "Test PR",
+      url: "https://github.com/octocat/hello-world/pull/123",
+      body: "![a](https://example.com/a.png)\n![dup](https://example.com/a.png)",
+      authorLogin: "author",
+      mergedByLogin: "merger",
+    });
+    vi.mocked(extractUniqueImageUrls).mockReturnValue(["https://example.com/a.png"]);
+    vi.mocked(buildImageBaseName).mockReturnValue("a.png");
+    onedrive.saveText
+      .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
+      .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
+
+    const response = await action({ request: buildRequest() } as never);
+    expect(response.status).toBe(200);
+    expect(onedrive.saveBinary).toHaveBeenCalledTimes(1);
+    const archiveBody = JSON.parse(onedrive.saveText.mock.calls[1][1] as string) as {
+      evidenceImages: Array<{ sourceUrl: string; status: string }>;
+    };
+    expect(archiveBody.evidenceImages).toHaveLength(1);
+    expect(archiveBody.evidenceImages[0]).toMatchObject({
+      sourceUrl: "https://example.com/a.png",
+      status: "success",
+    });
+  });
+
+  it("画像保存で失敗が混在しても処理継続し failed を記録する", async () => {
+    github.getPullRequest.mockResolvedValueOnce({
+      number: 123,
+      title: "Test PR",
+      url: "https://github.com/octocat/hello-world/pull/123",
+      body: "![a](https://example.com/a.png)\n![b](https://example.com/b.png)",
+      authorLogin: "author",
+      mergedByLogin: "merger",
+    });
+    vi.mocked(extractUniqueImageUrls).mockReturnValue([
+      "https://example.com/a.png",
+      "https://example.com/b.png",
+    ]);
+    vi.mocked(downloadImageWithRetry)
+      .mockResolvedValueOnce({ bytes: new Uint8Array([1]), contentType: "image/png" })
+      .mockResolvedValueOnce({ ok: false, errorReason: "HTTP_404" });
+    onedrive.saveText
+      .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
+      .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
+
+    const response = await action({ request: buildRequest() } as never);
+    expect(response.status).toBe(200);
+    const archiveBody = JSON.parse(onedrive.saveText.mock.calls[1][1] as string) as {
+      evidenceImages: Array<{ sourceUrl: string; status: string; errorReason: string | null }>;
+    };
+    expect(archiveBody.evidenceImages).toHaveLength(2);
+    expect(archiveBody.evidenceImages[0]).toMatchObject({
+      sourceUrl: "https://example.com/a.png",
+      status: "success",
+      errorReason: null,
+    });
+    expect(archiveBody.evidenceImages[1]).toMatchObject({
+      sourceUrl: "https://example.com/b.png",
+      status: "failed",
+      errorReason: "HTTP_404",
+    });
+  });
+
+  it("画像保存中のOneDrive認証切れは中断して401を返す", async () => {
+    github.getPullRequest.mockResolvedValueOnce({
+      number: 123,
+      title: "Test PR",
+      url: "https://github.com/octocat/hello-world/pull/123",
+      body: "![a](https://example.com/a.png)",
+      authorLogin: "author",
+      mergedByLogin: "merger",
+    });
+    vi.mocked(extractUniqueImageUrls).mockReturnValue(["https://example.com/a.png"]);
+    onedrive.saveBinary.mockRejectedValueOnce(
+      new Error("OneDrive API error (401) [code=InvalidAuthenticationToken]: token expired"),
+    );
+    onedrive.saveText.mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" });
+
+    const response = await action({ request: buildRequest() } as never);
+    const body = (await response.json()) as { ok: false; isAuthError: boolean };
+    expect(response.status).toBe(401);
+    expect(body.ok).toBe(false);
+    expect(body.isAuthError).toBe(true);
+    expect(onedrive.saveText).toHaveBeenCalledTimes(1);
   });
 
   it.each([

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -365,6 +365,37 @@ describe("api.onedrive.upload action", () => {
     expect(onedrive.saveText).toHaveBeenCalledTimes(1);
   });
 
+  it("非画像Content-Typeは保存せず failed として記録する", async () => {
+    github.getPullRequest.mockResolvedValueOnce({
+      number: 123,
+      title: "Test PR",
+      url: "https://github.com/octocat/hello-world/pull/123",
+      body: "![a](https://example.com/a.png)",
+      authorLogin: "author",
+      mergedByLogin: "merger",
+    });
+    vi.mocked(extractUniqueImageUrls).mockReturnValue(["https://example.com/a.png"]);
+    vi.mocked(downloadImageWithRetry).mockResolvedValueOnce({
+      bytes: new Uint8Array([1, 2, 3]),
+      contentType: "text/html",
+    });
+    onedrive.saveText
+      .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
+      .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
+
+    const response = await action({ request: buildRequest() } as never);
+    expect(response.status).toBe(200);
+    expect(onedrive.saveBinary).not.toHaveBeenCalled();
+    const archiveBody = JSON.parse(onedrive.saveText.mock.calls[1][1] as string) as {
+      evidenceImages: Array<{ status: string; errorReason: string | null }>;
+    };
+    expect(archiveBody.evidenceImages).toHaveLength(1);
+    expect(archiveBody.evidenceImages[0]).toMatchObject({
+      status: "failed",
+      errorReason: "UNSUPPORTED_CONTENT_TYPE: text/html",
+    });
+  });
+
   it.each([
     {
       status: 401,

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -414,9 +414,7 @@ describe("api.onedrive.upload action", () => {
     vi.mocked(downloadImageWithRetry)
       .mockResolvedValueOnce({ bytes: new Uint8Array([1]), contentType: "image/png" })
       .mockResolvedValueOnce({ bytes: new Uint8Array([2]), contentType: "image/png" });
-    onedrive.getItem
-      .mockResolvedValueOnce({ name: "image.png", webUrl: "https://example.com/existing-image" })
-      .mockResolvedValueOnce({ name: "image-1.png", webUrl: "https://example.com/existing-image-1" });
+    onedrive.getItem.mockResolvedValueOnce({ name: "image.png", webUrl: "https://example.com/existing-image" });
     onedrive.saveText
       .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
       .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
@@ -424,33 +422,59 @@ describe("api.onedrive.upload action", () => {
     const response = await action({ request: buildRequest() } as never);
 
     expect(response.status).toBe(200);
-    expect(onedrive.getItem).toHaveBeenCalledTimes(4);
+    expect(onedrive.getItem).toHaveBeenCalledTimes(1);
     expect(onedrive.getItem).toHaveBeenNthCalledWith(
       1,
       expect.stringContaining("/imgs/image.png"),
     );
-    expect(onedrive.getItem).toHaveBeenNthCalledWith(
-      2,
-      expect.stringContaining("/imgs/image-1.png"),
-    );
-    expect(onedrive.getItem).toHaveBeenNthCalledWith(
-      3,
-      expect.stringContaining("/imgs/image-2.png"),
-    );
-    expect(onedrive.getItem).toHaveBeenNthCalledWith(
-      4,
-      expect.stringContaining("/imgs/image-3.png"),
-    );
     expect(onedrive.saveBinary).toHaveBeenCalledTimes(2);
     expect(onedrive.saveBinary).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining("/imgs/image-2.png"),
+      expect.stringContaining("/imgs/image-1.png"),
       expect.any(Uint8Array),
       "image/png",
     );
     expect(onedrive.saveBinary).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining("/imgs/image-3.png"),
+      expect.stringContaining("/imgs/image-2.png"),
+      expect.any(Uint8Array),
+      "image/png",
+    );
+  });
+
+  it("saveBinary で 412 競合が起きた場合は再採番して再試行する", async () => {
+    github.getPullRequest.mockResolvedValueOnce({
+      number: 123,
+      title: "Test PR",
+      url: "https://github.com/octocat/hello-world/pull/123",
+      body: "![a](https://example.com/a.png)",
+      authorLogin: "author",
+      mergedByLogin: "merger",
+    });
+    vi.mocked(extractUniqueImageUrls).mockReturnValue(["https://example.com/a.png"]);
+    vi.mocked(buildImageBaseName).mockReturnValue("image.png");
+    vi.mocked(downloadImageWithRetry).mockResolvedValueOnce({ bytes: new Uint8Array([1]), contentType: "image/png" });
+    onedrive.getItem.mockResolvedValueOnce({ name: "image.png", webUrl: "https://example.com/existing-image" });
+    onedrive.saveBinary
+      .mockRejectedValueOnce(new OneDriveApiError("name conflict", 412, "nameAlreadyExists"))
+      .mockResolvedValueOnce({ name: "image-2.png", webUrl: "https://example.com/image-2.png" });
+    onedrive.saveText
+      .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
+      .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
+
+    const response = await action({ request: buildRequest() } as never);
+    expect(response.status).toBe(200);
+    expect(onedrive.getItem).toHaveBeenCalledTimes(1);
+    expect(onedrive.saveBinary).toHaveBeenCalledTimes(2);
+    expect(onedrive.saveBinary).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("/imgs/image-1.png"),
+      expect.any(Uint8Array),
+      "image/png",
+    );
+    expect(onedrive.saveBinary).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("/imgs/image-2.png"),
       expect.any(Uint8Array),
       "image/png",
     );

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -406,6 +406,45 @@ describe("api.onedrive.upload action", () => {
     expect(onedrive.saveText).toHaveBeenCalledTimes(1);
   });
 
+  it("画像保存途中の認証切れでは保存済み画像をロールバック削除する", async () => {
+    github.getPullRequest.mockResolvedValueOnce({
+      number: 123,
+      title: "Test PR",
+      url: "https://github.com/octocat/hello-world/pull/123",
+      body: "![a](https://example.com/a.png)\n![b](https://example.com/b.png)",
+      authorLogin: "author",
+      mergedByLogin: "merger",
+    });
+    vi.mocked(extractUniqueImageUrls).mockReturnValue([
+      "https://example.com/a.png",
+      "https://example.com/b.png",
+    ]);
+    vi.mocked(buildImageBaseName).mockReturnValue("image.png");
+    vi.mocked(downloadImageWithRetry)
+      .mockResolvedValueOnce({ bytes: new Uint8Array([1]), contentType: "image/png" })
+      .mockResolvedValueOnce({ bytes: new Uint8Array([2]), contentType: "image/png" });
+    onedrive.saveText.mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" });
+    onedrive.saveBinary
+      .mockResolvedValueOnce({ name: "image.png", webUrl: "https://example.com/image.png" })
+      .mockRejectedValueOnce(
+        new Error("OneDrive API error (401) [code=InvalidAuthenticationToken]: token expired"),
+      );
+
+    const response = await action({ request: buildRequest() } as never);
+    const body = (await response.json()) as { ok: false; isAuthError: boolean };
+
+    expect(response.status).toBe(401);
+    expect(body.ok).toBe(false);
+    expect(body.isAuthError).toBe(true);
+    const deletedPaths = onedrive.deleteItem.mock.calls.map((args) => args[0] as string);
+    expect(deletedPaths).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("/PullRequests/PR123-Test-PR/imgs/image.png"),
+        expect.stringContaining("/PullRequests/PR123-Test-PR/description.md"),
+      ]),
+    );
+  });
+
   it("非画像Content-Typeは保存せず failed として記録する", async () => {
     github.getPullRequest.mockResolvedValueOnce({
       number: 123,

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -507,6 +507,60 @@ describe("api.onedrive.upload action", () => {
     });
   });
 
+  it("画像件数が上限を超える場合は超過分をスキップして failed 記録する", async () => {
+    const previousLimit = process.env.ONEDRIVE_EVIDENCE_IMAGE_MAX_COUNT;
+    process.env.ONEDRIVE_EVIDENCE_IMAGE_MAX_COUNT = "2";
+    try {
+      const urls = [
+        "https://example.com/a.png",
+        "https://example.com/b.png",
+        "https://example.com/c.png",
+        "https://example.com/d.png",
+      ];
+      github.getPullRequest.mockResolvedValueOnce({
+        number: 123,
+        title: "Test PR",
+        url: "https://github.com/octocat/hello-world/pull/123",
+        body: urls.map((url, i) => `![${i}](${url})`).join("\n"),
+        authorLogin: "author",
+        mergedByLogin: "merger",
+      });
+      vi.mocked(extractUniqueImageUrls).mockReturnValue(urls);
+      vi.mocked(buildImageBaseName).mockReturnValue("image.png");
+      vi.mocked(downloadImageWithRetry)
+        .mockResolvedValueOnce({ bytes: new Uint8Array([1]), contentType: "image/png" })
+        .mockResolvedValueOnce({ bytes: new Uint8Array([2]), contentType: "image/png" });
+      onedrive.saveText
+        .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
+        .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
+
+      const response = await action({ request: buildRequest() } as never);
+      expect(response.status).toBe(200);
+      expect(downloadImageWithRetry).toHaveBeenCalledTimes(2);
+      expect(onedrive.saveBinary).toHaveBeenCalledTimes(2);
+      const archiveBody = JSON.parse(onedrive.saveText.mock.calls[1][1] as string) as {
+        evidenceImages: Array<{ sourceUrl: string; status: string; errorReason: string | null }>;
+      };
+      expect(archiveBody.evidenceImages).toHaveLength(4);
+      expect(archiveBody.evidenceImages[2]).toMatchObject({
+        sourceUrl: "https://example.com/c.png",
+        status: "failed",
+        errorReason: "IMAGE_LIMIT_EXCEEDED",
+      });
+      expect(archiveBody.evidenceImages[3]).toMatchObject({
+        sourceUrl: "https://example.com/d.png",
+        status: "failed",
+        errorReason: "IMAGE_LIMIT_EXCEEDED",
+      });
+    } finally {
+      if (previousLimit === undefined) {
+        delete process.env.ONEDRIVE_EVIDENCE_IMAGE_MAX_COUNT;
+      } else {
+        process.env.ONEDRIVE_EVIDENCE_IMAGE_MAX_COUNT = previousLimit;
+      }
+    }
+  });
+
   it.each([
     {
       status: 401,

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -369,7 +369,9 @@ describe("api.onedrive.upload action", () => {
     vi.mocked(downloadImageWithRetry)
       .mockResolvedValueOnce({ bytes: new Uint8Array([1]), contentType: "image/png" })
       .mockResolvedValueOnce({ bytes: new Uint8Array([2]), contentType: "image/png" });
-    onedrive.getItem.mockResolvedValueOnce({ name: "image.png", webUrl: "https://example.com/existing-image" });
+    onedrive.getItem
+      .mockResolvedValueOnce({ name: "image.png", webUrl: "https://example.com/existing-image" })
+      .mockResolvedValueOnce({ name: "image-1.png", webUrl: "https://example.com/existing-image-1" });
     onedrive.saveText
       .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
       .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
@@ -377,17 +379,33 @@ describe("api.onedrive.upload action", () => {
     const response = await action({ request: buildRequest() } as never);
 
     expect(response.status).toBe(200);
-    expect(onedrive.getItem).toHaveBeenCalledTimes(1);
+    expect(onedrive.getItem).toHaveBeenCalledTimes(4);
+    expect(onedrive.getItem).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("/imgs/image.png"),
+    );
+    expect(onedrive.getItem).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("/imgs/image-1.png"),
+    );
+    expect(onedrive.getItem).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining("/imgs/image-2.png"),
+    );
+    expect(onedrive.getItem).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining("/imgs/image-3.png"),
+    );
     expect(onedrive.saveBinary).toHaveBeenCalledTimes(2);
     expect(onedrive.saveBinary).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining("/imgs/image-1.png"),
+      expect.stringContaining("/imgs/image-2.png"),
       expect.any(Uint8Array),
       "image/png",
     );
     expect(onedrive.saveBinary).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining("/imgs/image-2.png"),
+      expect.stringContaining("/imgs/image-3.png"),
       expect.any(Uint8Array),
       "image/png",
     );

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -476,6 +476,37 @@ describe("api.onedrive.upload action", () => {
     });
   });
 
+  it("SVGは保存せず failed として記録する", async () => {
+    github.getPullRequest.mockResolvedValueOnce({
+      number: 123,
+      title: "Test PR",
+      url: "https://github.com/octocat/hello-world/pull/123",
+      body: "![a](https://example.com/a.svg)",
+      authorLogin: "author",
+      mergedByLogin: "merger",
+    });
+    vi.mocked(extractUniqueImageUrls).mockReturnValue(["https://example.com/a.svg"]);
+    vi.mocked(downloadImageWithRetry).mockResolvedValueOnce({
+      bytes: new Uint8Array([1, 2, 3]),
+      contentType: "image/svg+xml",
+    });
+    onedrive.saveText
+      .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
+      .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
+
+    const response = await action({ request: buildRequest() } as never);
+    expect(response.status).toBe(200);
+    expect(onedrive.saveBinary).not.toHaveBeenCalled();
+    const archiveBody = JSON.parse(onedrive.saveText.mock.calls[1][1] as string) as {
+      evidenceImages: Array<{ status: string; errorReason: string | null }>;
+    };
+    expect(archiveBody.evidenceImages).toHaveLength(1);
+    expect(archiveBody.evidenceImages[0]).toMatchObject({
+      status: "failed",
+      errorReason: "UNSUPPORTED_CONTENT_TYPE: image/svg+xml",
+    });
+  });
+
   it.each([
     {
       status: 401,

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -561,6 +561,63 @@ describe("api.onedrive.upload action", () => {
     }
   });
 
+  it("非認証のOneDriveエラーが2件連続したら残り画像をスキップする", async () => {
+    const urls = [
+      "https://example.com/a.png",
+      "https://example.com/b.png",
+      "https://example.com/c.png",
+      "https://example.com/d.png",
+    ];
+    github.getPullRequest.mockResolvedValueOnce({
+      number: 123,
+      title: "Test PR",
+      url: "https://github.com/octocat/hello-world/pull/123",
+      body: urls.map((url, i) => `![${i}](${url})`).join("\n"),
+      authorLogin: "author",
+      mergedByLogin: "merger",
+    });
+    vi.mocked(extractUniqueImageUrls).mockReturnValue(urls);
+    vi.mocked(buildImageBaseName).mockReturnValue("image.png");
+    vi.mocked(downloadImageWithRetry)
+      .mockResolvedValueOnce({ bytes: new Uint8Array([1]), contentType: "image/png" })
+      .mockResolvedValueOnce({ bytes: new Uint8Array([2]), contentType: "image/png" });
+    onedrive.saveBinary
+      .mockRejectedValueOnce(new Error("OneDrive API error (507) [code=insufficientStorage]: details-1"))
+      .mockRejectedValueOnce(new Error("OneDrive API error (507) [code=insufficientStorage]: details-2"));
+    onedrive.saveText
+      .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
+      .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
+
+    const response = await action({ request: buildRequest() } as never);
+    expect(response.status).toBe(200);
+    expect(downloadImageWithRetry).toHaveBeenCalledTimes(2);
+    expect(onedrive.saveBinary).toHaveBeenCalledTimes(2);
+    const archiveBody = JSON.parse(onedrive.saveText.mock.calls[1][1] as string) as {
+      evidenceImages: Array<{ sourceUrl: string; status: string; errorReason: string | null }>;
+    };
+    expect(archiveBody.evidenceImages).toHaveLength(4);
+    expect(archiveBody.evidenceImages[0]).toMatchObject({
+      sourceUrl: "https://example.com/a.png",
+      status: "failed",
+      errorReason: "ONEDRIVE_SAVE_FAILED",
+    });
+    expect(archiveBody.evidenceImages[1]).toMatchObject({
+      sourceUrl: "https://example.com/b.png",
+      status: "failed",
+      errorReason: "ONEDRIVE_SAVE_FAILED",
+    });
+    expect(archiveBody.evidenceImages[2]).toMatchObject({
+      sourceUrl: "https://example.com/c.png",
+      status: "failed",
+      errorReason: "ONEDRIVE_SAVE_SKIPPED_AFTER_CONSECUTIVE_FAILURE",
+    });
+    expect(archiveBody.evidenceImages[3]).toMatchObject({
+      sourceUrl: "https://example.com/d.png",
+      status: "failed",
+      errorReason: "ONEDRIVE_SAVE_SKIPPED_AFTER_CONSECUTIVE_FAILURE",
+    });
+  });
+
   it.each([
     {
       status: 401,

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -571,6 +571,42 @@ describe("api.onedrive.upload action", () => {
     }
   });
 
+  it("画像サイズ上限が単純アップロード上限を超える場合は250MBにクランプする", async () => {
+    const previousMaxKb = process.env.ONEDRIVE_EVIDENCE_IMAGE_MAX_KB;
+    process.env.ONEDRIVE_EVIDENCE_IMAGE_MAX_KB = "999999";
+    try {
+      github.getPullRequest.mockResolvedValueOnce({
+        number: 123,
+        title: "Test PR",
+        url: "https://github.com/octocat/hello-world/pull/123",
+        body: "![a](https://example.com/a.png)",
+        authorLogin: "author",
+        mergedByLogin: "merger",
+      });
+      vi.mocked(extractUniqueImageUrls).mockReturnValue(["https://example.com/a.png"]);
+      vi.mocked(downloadImageWithRetry).mockResolvedValueOnce({
+        bytes: new Uint8Array([1]),
+        contentType: "image/png",
+      });
+      onedrive.saveText
+        .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
+        .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
+
+      const response = await action({ request: buildRequest() } as never);
+      expect(response.status).toBe(200);
+      expect(downloadImageWithRetry).toHaveBeenCalledWith(
+        "https://example.com/a.png",
+        expect.objectContaining({ maxBytes: 250 * 1024 * 1024 }),
+      );
+    } finally {
+      if (previousMaxKb === undefined) {
+        delete process.env.ONEDRIVE_EVIDENCE_IMAGE_MAX_KB;
+      } else {
+        process.env.ONEDRIVE_EVIDENCE_IMAGE_MAX_KB = previousMaxKb;
+      }
+    }
+  });
+
   it("非認証のOneDriveエラーが2件連続したら残り画像をスキップする", async () => {
     const urls = [
       "https://example.com/a.png",

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -342,6 +342,47 @@ describe("api.onedrive.upload action", () => {
     });
   });
 
+  it("同名画像が既存でも getItem 連打せずローカル採番で保存する", async () => {
+    github.getPullRequest.mockResolvedValueOnce({
+      number: 123,
+      title: "Test PR",
+      url: "https://github.com/octocat/hello-world/pull/123",
+      body: "![a](https://example.com/a.png)\n![b](https://example.com/b.png)",
+      authorLogin: "author",
+      mergedByLogin: "merger",
+    });
+    vi.mocked(extractUniqueImageUrls).mockReturnValue([
+      "https://example.com/a.png",
+      "https://example.com/b.png",
+    ]);
+    vi.mocked(buildImageBaseName).mockReturnValue("image.png");
+    vi.mocked(downloadImageWithRetry)
+      .mockResolvedValueOnce({ bytes: new Uint8Array([1]), contentType: "image/png" })
+      .mockResolvedValueOnce({ bytes: new Uint8Array([2]), contentType: "image/png" });
+    onedrive.getItem.mockResolvedValueOnce({ name: "image.png", webUrl: "https://example.com/existing-image" });
+    onedrive.saveText
+      .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
+      .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
+
+    const response = await action({ request: buildRequest() } as never);
+
+    expect(response.status).toBe(200);
+    expect(onedrive.getItem).toHaveBeenCalledTimes(1);
+    expect(onedrive.saveBinary).toHaveBeenCalledTimes(2);
+    expect(onedrive.saveBinary).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("/imgs/image-1.png"),
+      expect.any(Uint8Array),
+      "image/png",
+    );
+    expect(onedrive.saveBinary).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("/imgs/image-2.png"),
+      expect.any(Uint8Array),
+      "image/png",
+    );
+  });
+
   it("画像保存中のOneDrive認証切れは中断して401を返す", async () => {
     github.getPullRequest.mockResolvedValueOnce({
       number: 123,

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -193,6 +193,51 @@ describe("api.onedrive.upload action", () => {
     warnSpy.mockRestore();
   });
 
+  it("archive保存失敗後に画像ロールバックが一部失敗した場合は partial を記録する", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    github.getPullRequest.mockResolvedValueOnce({
+      number: 123,
+      title: "Test PR",
+      url: "https://github.com/octocat/hello-world/pull/123",
+      body: "![a](https://example.com/a.png)\n![b](https://example.com/b.png)",
+      authorLogin: "author",
+      mergedByLogin: "merger",
+    });
+    vi.mocked(extractUniqueImageUrls).mockReturnValue([
+      "https://example.com/a.png",
+      "https://example.com/b.png",
+    ]);
+    vi.mocked(downloadImageWithRetry)
+      .mockResolvedValueOnce({ bytes: new Uint8Array([1]), contentType: "image/png" })
+      .mockResolvedValueOnce({ bytes: new Uint8Array([2]), contentType: "image/png" });
+    onedrive.saveBinary
+      .mockResolvedValueOnce({ name: "image-a.png", webUrl: "https://example.com/a" })
+      .mockResolvedValueOnce({ name: "image-b.png", webUrl: "https://example.com/b" });
+    onedrive.saveText
+      .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
+      .mockRejectedValueOnce(new Error("archive write failed"));
+    onedrive.deleteItem
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("permission denied"))
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+
+    const response = await action({ request: buildRequest() } as never);
+    const body = (await response.json()) as { ok: false; error: string };
+
+    expect(response.status).toBe(502);
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("OneDrive への保存に失敗しました。しばらくしてから再実行してください。");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "OneDrive upload failed.",
+      expect.objectContaining({
+        message: expect.stringContaining("evidenceCleanup=partial"),
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
   it("OneDrive認証エラーを 401 / isAuthError=true で返す", async () => {
     onedrive.getDriveInfo.mockRejectedValue(
       new Error("OneDrive API error (401) [code=InvalidAuthenticationToken]: token expired"),
@@ -735,6 +780,97 @@ describe("api.onedrive.upload action", () => {
       status: "failed",
       errorReason: "ONEDRIVE_SAVE_SKIPPED_AFTER_CONSECUTIVE_FAILURE",
     });
+  });
+
+  it("OneDriveエラーの間にダウンロード失敗がある場合はカウンタをリセットする", async () => {
+    const urls = [
+      "https://example.com/a.png",
+      "https://example.com/b.png",
+      "https://example.com/c.png",
+      "https://example.com/d.png",
+    ];
+    github.getPullRequest.mockResolvedValueOnce({
+      number: 123,
+      title: "Test PR",
+      url: "https://github.com/octocat/hello-world/pull/123",
+      body: urls.map((url, i) => `![${i}](${url})`).join("\n"),
+      authorLogin: "author",
+      mergedByLogin: "merger",
+    });
+    vi.mocked(extractUniqueImageUrls).mockReturnValue(urls);
+    vi.mocked(buildImageBaseName).mockReturnValue("image.png");
+    vi.mocked(downloadImageWithRetry)
+      .mockResolvedValueOnce({ bytes: new Uint8Array([1]), contentType: "image/png" })
+      .mockResolvedValueOnce({ ok: false, errorReason: "TIMEOUT" })
+      .mockResolvedValueOnce({ bytes: new Uint8Array([3]), contentType: "image/png" })
+      .mockResolvedValueOnce({ bytes: new Uint8Array([4]), contentType: "image/png" });
+    onedrive.saveBinary
+      .mockRejectedValueOnce(new OneDriveApiError("quota exceeded", 507, "insufficientStorage"))
+      .mockRejectedValueOnce(new OneDriveApiError("quota still exceeded", 507, "insufficientStorage"))
+      .mockResolvedValueOnce({ name: "image.png", webUrl: "https://example.com/image.png" });
+    onedrive.saveText
+      .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
+      .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
+
+    const response = await action({ request: buildRequest() } as never);
+    expect(response.status).toBe(200);
+    expect(downloadImageWithRetry).toHaveBeenCalledTimes(4);
+    expect(onedrive.saveBinary).toHaveBeenCalledTimes(3);
+    const archiveBody = JSON.parse(onedrive.saveText.mock.calls[1][1] as string) as {
+      evidenceImages: Array<{ sourceUrl: string; status: string; errorReason: string | null }>;
+    };
+    expect(archiveBody.evidenceImages).toHaveLength(4);
+    expect(archiveBody.evidenceImages[0]).toMatchObject({ status: "failed", errorReason: "ONEDRIVE_SAVE_FAILED" });
+    expect(archiveBody.evidenceImages[1]).toMatchObject({ status: "failed", errorReason: "TIMEOUT" });
+    expect(archiveBody.evidenceImages[2]).toMatchObject({ status: "failed", errorReason: "ONEDRIVE_SAVE_FAILED" });
+    expect(archiveBody.evidenceImages[3]).toMatchObject({ status: "success" });
+  });
+
+  it("OneDriveエラーの間に非画像Content-Type失敗がある場合はカウンタをリセットする", async () => {
+    const urls = [
+      "https://example.com/a.png",
+      "https://example.com/b.png",
+      "https://example.com/c.png",
+      "https://example.com/d.png",
+    ];
+    github.getPullRequest.mockResolvedValueOnce({
+      number: 123,
+      title: "Test PR",
+      url: "https://github.com/octocat/hello-world/pull/123",
+      body: urls.map((url, i) => `![${i}](${url})`).join("\n"),
+      authorLogin: "author",
+      mergedByLogin: "merger",
+    });
+    vi.mocked(extractUniqueImageUrls).mockReturnValue(urls);
+    vi.mocked(buildImageBaseName).mockReturnValue("image.png");
+    vi.mocked(downloadImageWithRetry)
+      .mockResolvedValueOnce({ bytes: new Uint8Array([1]), contentType: "image/png" })
+      .mockResolvedValueOnce({ bytes: new Uint8Array([2]), contentType: "text/html" })
+      .mockResolvedValueOnce({ bytes: new Uint8Array([3]), contentType: "image/png" })
+      .mockResolvedValueOnce({ bytes: new Uint8Array([4]), contentType: "image/png" });
+    onedrive.saveBinary
+      .mockRejectedValueOnce(new OneDriveApiError("quota exceeded", 507, "insufficientStorage"))
+      .mockRejectedValueOnce(new OneDriveApiError("quota still exceeded", 507, "insufficientStorage"))
+      .mockResolvedValueOnce({ name: "image.png", webUrl: "https://example.com/image.png" });
+    onedrive.saveText
+      .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
+      .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
+
+    const response = await action({ request: buildRequest() } as never);
+    expect(response.status).toBe(200);
+    expect(downloadImageWithRetry).toHaveBeenCalledTimes(4);
+    expect(onedrive.saveBinary).toHaveBeenCalledTimes(3);
+    const archiveBody = JSON.parse(onedrive.saveText.mock.calls[1][1] as string) as {
+      evidenceImages: Array<{ sourceUrl: string; status: string; errorReason: string | null }>;
+    };
+    expect(archiveBody.evidenceImages).toHaveLength(4);
+    expect(archiveBody.evidenceImages[0]).toMatchObject({ status: "failed", errorReason: "ONEDRIVE_SAVE_FAILED" });
+    expect(archiveBody.evidenceImages[1]).toMatchObject({
+      status: "failed",
+      errorReason: "UNSUPPORTED_CONTENT_TYPE: text/html",
+    });
+    expect(archiveBody.evidenceImages[2]).toMatchObject({ status: "failed", errorReason: "ONEDRIVE_SAVE_FAILED" });
+    expect(archiveBody.evidenceImages[3]).toMatchObject({ status: "success" });
   });
 
   it.each([

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -551,16 +551,11 @@ describe("api.onedrive.upload action", () => {
       const archiveBody = JSON.parse(onedrive.saveText.mock.calls[1][1] as string) as {
         evidenceImages: Array<{ sourceUrl: string; status: string; errorReason: string | null }>;
       };
-      expect(archiveBody.evidenceImages).toHaveLength(4);
+      expect(archiveBody.evidenceImages).toHaveLength(3);
       expect(archiveBody.evidenceImages[2]).toMatchObject({
         sourceUrl: "https://example.com/c.png",
         status: "failed",
-        errorReason: "IMAGE_LIMIT_EXCEEDED",
-      });
-      expect(archiveBody.evidenceImages[3]).toMatchObject({
-        sourceUrl: "https://example.com/d.png",
-        status: "failed",
-        errorReason: "IMAGE_LIMIT_EXCEEDED",
+        errorReason: "IMAGE_LIMIT_EXCEEDED_REMAINING:2",
       });
     } finally {
       if (previousLimit === undefined) {

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -11,7 +11,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { action } from "./api.onedrive.upload";
 import { createGitHubServiceFromEnv } from "../services/github.server";
-import { createOneDriveServiceFromEnv } from "../services/onedrive.server";
+import { createOneDriveServiceFromEnv, OneDriveApiError } from "../services/onedrive.server";
 import { parseChecklist } from "../services/checklist";
 import { verifyCsrfToken } from "../services/csrf.server";
 import { validatePrRefInput } from "../services/validation";
@@ -28,6 +28,16 @@ vi.mock("../services/github.server", () => ({
 
 vi.mock("../services/onedrive.server", () => ({
   createOneDriveServiceFromEnv: vi.fn(),
+  OneDriveApiError: class OneDriveApiError extends Error {
+    status: number; // HTTPステータスコード
+    code?: string; // APIエラーコード（存在する場合）
+    constructor(message: string, status: number, code?: string) {
+      super(message); // Errorのmessageプロパティに設定
+      this.name = "OneDriveApiError";
+      this.status = status;
+      this.code = code;
+    }
+  },
 }));
 
 vi.mock("../services/checklist", () => ({
@@ -582,8 +592,8 @@ describe("api.onedrive.upload action", () => {
       .mockResolvedValueOnce({ bytes: new Uint8Array([1]), contentType: "image/png" })
       .mockResolvedValueOnce({ bytes: new Uint8Array([2]), contentType: "image/png" });
     onedrive.saveBinary
-      .mockRejectedValueOnce(new Error("OneDrive API error (507) [code=insufficientStorage]: details-1"))
-      .mockRejectedValueOnce(new Error("OneDrive API error (507) [code=insufficientStorage]: details-2"));
+      .mockRejectedValueOnce(new OneDriveApiError("storage quota exceeded", 507, "insufficientStorage"))
+      .mockRejectedValueOnce(new OneDriveApiError("quota still exceeded", 507, "insufficientStorage"));
     onedrive.saveText
       .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
       .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
@@ -610,6 +620,66 @@ describe("api.onedrive.upload action", () => {
       sourceUrl: "https://example.com/c.png",
       status: "failed",
       errorReason: "ONEDRIVE_SAVE_SKIPPED_AFTER_CONSECUTIVE_FAILURE",
+    });
+    expect(archiveBody.evidenceImages[3]).toMatchObject({
+      sourceUrl: "https://example.com/d.png",
+      status: "failed",
+      errorReason: "ONEDRIVE_SAVE_SKIPPED_AFTER_CONSECUTIVE_FAILURE",
+    });
+  });
+
+  it("OneDrive APIエラーの間に非OneDriveエラーがあっても閾値到達後は残り画像をスキップする", async () => {
+    const urls = [
+      "https://example.com/a.png",
+      "https://example.com/b.png",
+      "https://example.com/c.png",
+      "https://example.com/d.png",
+    ];
+    github.getPullRequest.mockResolvedValueOnce({
+      number: 123,
+      title: "Test PR",
+      url: "https://github.com/octocat/hello-world/pull/123",
+      body: urls.map((url, i) => `![${i}](${url})`).join("\n"),
+      authorLogin: "author",
+      mergedByLogin: "merger",
+    });
+    vi.mocked(extractUniqueImageUrls).mockReturnValue(urls);
+    vi.mocked(buildImageBaseName).mockReturnValue("image.png");
+    vi.mocked(downloadImageWithRetry)
+      .mockResolvedValueOnce({ bytes: new Uint8Array([1]), contentType: "image/png" })
+      .mockResolvedValueOnce({ bytes: new Uint8Array([2]), contentType: "image/png" })
+      .mockResolvedValueOnce({ bytes: new Uint8Array([3]), contentType: "image/png" });
+    onedrive.saveBinary
+      .mockRejectedValueOnce(new OneDriveApiError("quota exceeded", 507, "insufficientStorage"))
+      .mockRejectedValueOnce(new Error("socket hang up"))
+      .mockRejectedValueOnce(new OneDriveApiError("quota still exceeded", 507, "insufficientStorage"));
+    onedrive.saveText
+      .mockResolvedValueOnce({ name: "description.md", webUrl: "https://example.com/desc" })
+      .mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });
+
+    const response = await action({ request: buildRequest() } as never);
+    expect(response.status).toBe(200);
+    expect(downloadImageWithRetry).toHaveBeenCalledTimes(3);
+    expect(onedrive.saveBinary).toHaveBeenCalledTimes(3);
+
+    const archiveBody = JSON.parse(onedrive.saveText.mock.calls[1][1] as string) as {
+      evidenceImages: Array<{ sourceUrl: string; status: string; errorReason: string | null }>;
+    };
+    expect(archiveBody.evidenceImages).toHaveLength(4);
+    expect(archiveBody.evidenceImages[0]).toMatchObject({
+      sourceUrl: "https://example.com/a.png",
+      status: "failed",
+      errorReason: "ONEDRIVE_SAVE_FAILED",
+    });
+    expect(archiveBody.evidenceImages[1]).toMatchObject({
+      sourceUrl: "https://example.com/b.png",
+      status: "failed",
+      errorReason: "socket hang up",
+    });
+    expect(archiveBody.evidenceImages[2]).toMatchObject({
+      sourceUrl: "https://example.com/c.png",
+      status: "failed",
+      errorReason: "ONEDRIVE_SAVE_FAILED",
     });
     expect(archiveBody.evidenceImages[3]).toMatchObject({
       sourceUrl: "https://example.com/d.png",

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -69,6 +69,7 @@ const MAX_ONEDRIVE_SIMPLE_UPLOAD_BYTES = 250 * 1024 * 1024; // Microsoft Graph �
 const MAX_CONSECUTIVE_ONEDRIVE_SAVE_FAILURES = 2;
 const ONEDRIVE_SAVE_FAILED_REASON = "ONEDRIVE_SAVE_FAILED";
 const ONEDRIVE_SAVE_SKIPPED_REASON = "ONEDRIVE_SAVE_SKIPPED_AFTER_CONSECUTIVE_FAILURE";
+const IMAGE_LIMIT_EXCEEDED_REMAINING_REASON = "IMAGE_LIMIT_EXCEEDED_REMAINING";
 
 /*
 / 画像URL抽出の重複排除、ダウンロード再試行、拡張子補完の契約を固定するため、
@@ -481,14 +482,15 @@ async function saveEvidenceImages({
 
   for (const [index, sourceUrl] of urls.entries()) {
     if (index >= maxImageCount) {
+      const remainingCount = urls.length - index;
       results.push({
         sourceUrl,
         status: "failed",
         fileName: null,
         onedrivePath: null,
-        errorReason: "IMAGE_LIMIT_EXCEEDED",
+        errorReason: `${IMAGE_LIMIT_EXCEEDED_REMAINING_REASON}:${remainingCount}`,
       });
-      continue;
+      break;
     }
     if (consecutiveOneDriveSaveFailures >= MAX_CONSECUTIVE_ONEDRIVE_SAVE_FAILURES) {
       results.push({

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -67,6 +67,7 @@ const BYTES_PER_KILOBYTE = 1024;
 const DEFAULT_EVIDENCE_IMAGE_MAX_COUNT = 20; // 画像の枚数が多すぎると保存処理が重くなったり、OneDrive の容量を圧迫したりする可能性があるため、上限を設ける。
 const MAX_ONEDRIVE_SIMPLE_UPLOAD_BYTES = 250 * 1024 * 1024; // Microsoft Graph 単純アップロードの上限
 const MAX_CONSECUTIVE_ONEDRIVE_SAVE_FAILURES = 2;
+const MAX_SAVE_CONFLICT_RETRIES = 20;
 const ONEDRIVE_SAVE_FAILED_REASON = "ONEDRIVE_SAVE_FAILED";
 const ONEDRIVE_SAVE_SKIPPED_REASON = "ONEDRIVE_SAVE_SKIPPED_AFTER_CONSECUTIVE_FAILURE";
 const IMAGE_LIMIT_EXCEEDED_REMAINING_REASON = "IMAGE_LIMIT_EXCEEDED_REMAINING";
@@ -545,14 +546,30 @@ async function saveEvidenceImages({
 
     try {
       const baseName = buildImageBaseName(sourceUrl, downloaded.contentType);
-      const fileName = await resolveEvidenceFileName({
+      let fileName = await resolveEvidenceFileName({
         onedrive,
         folderPath: imagesFolder,
         baseName,
         reservedNames,
       });
-      const onedrivePath = `${imagesFolder}/${fileName}`;
-      await onedrive.saveBinary(onedrivePath, downloaded.bytes, downloaded.contentType ?? undefined);
+      let onedrivePath = `${imagesFolder}/${fileName}`;
+      for (let retry = 0; retry <= MAX_SAVE_CONFLICT_RETRIES; retry += 1) {
+        try {
+          await onedrive.saveBinary(onedrivePath, downloaded.bytes, downloaded.contentType ?? undefined);
+          break;
+        } catch (saveError) {
+          if (
+            saveError instanceof OneDriveApiError &&
+            saveError.status === 412 &&
+            retry < MAX_SAVE_CONFLICT_RETRIES
+          ) {
+            fileName = allocateLocalUniqueName(baseName, reservedNames);
+            onedrivePath = `${imagesFolder}/${fileName}`;
+            continue;
+          }
+          throw saveError;
+        }
+      }
       results.push({
         sourceUrl,
         status: "success",
@@ -650,17 +667,24 @@ async function resolveEvidenceFileName({
   baseName: string;
   reservedNames: Set<string>;
 }): Promise<string> {
-  // 候補ファイル名ごとに OneDrive 上の存在確認を行い、既存ファイルの上書きを防ぐ。
-  for (let index = 0; index < 5000; index += 1) {
-    const candidate = index === 0 ? baseName : buildIndexedFileName(baseName, index);
-    if (reservedNames.has(candidate)) {
-      continue;
-    }
-    const existing = await onedrive.getItem(`${folderPath}/${candidate}`);
-    if (existing) {
-      reservedNames.add(candidate);
-      continue;
-    }
+  // すでに予約済みならローカル採番を使う。同一リクエスト内の衝突を回避する。
+  if (reservedNames.has(baseName)) {
+    return allocateLocalUniqueName(baseName, reservedNames);
+  }
+  // OneDrive 上の存在確認は初回候補のみ。以降の衝突は saveBinary 側の 412 で検知して再採番する。
+  const existing = await onedrive.getItem(`${folderPath}/${baseName}`);
+  if (!existing) {
+    reservedNames.add(baseName);
+    return baseName;
+  }
+  reservedNames.add(baseName);
+  return allocateLocalUniqueName(baseName, reservedNames);
+}
+
+function allocateLocalUniqueName(baseName: string, reservedNames: Set<string>): string {
+  for (let index = 1; index <= 5000; index += 1) {
+    const candidate = buildIndexedFileName(baseName, index);
+    if (reservedNames.has(candidate)) continue;
     reservedNames.add(candidate);
     return candidate;
   }

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -62,6 +62,23 @@ type EvidenceImageRecord = {
   onedrivePath: string | null;
   errorReason: string | null;
 };
+const DEFAULT_EVIDENCE_IMAGE_MAX_KB = 10 * 1024;
+const BYTES_PER_KILOBYTE = 1024;
+
+/*
+/ 画像URL抽出の重複排除、ダウンロード再試行、拡張子補完の契約を固定するため、
+/ これらの機能を提供する関数は services/evidence-images.server.ts に切り出している。
+/ これにより、これらの機能の実装を変更する際に、ルートハンドラーのコードを変更せずに済むようになる。 
+*/
+class EvidenceImagesSaveError extends Error {
+  readonly savedImagePaths: string[];
+
+  constructor(message: string, savedImagePaths: string[]) {
+    super(message);
+    this.name = "EvidenceImagesSaveError";
+    this.savedImagePaths = savedImagePaths;
+  }
+}
 
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
@@ -140,6 +157,7 @@ export async function action({ request }: ActionFunctionArgs) {
     let rollbackAttempted = false;
     let rollbackSucceeded = false;
     let rollbackFailureReason = "unknown";
+    let rollbackEvidenceCleanup = "not-attempted";
     let rollbackFolderCleanup = "not-attempted";
 
     try {
@@ -178,6 +196,35 @@ export async function action({ request }: ActionFunctionArgs) {
     } catch (writeError) {
       if (descriptionMd && !archiveJson) {
         rollbackAttempted = true;
+        const savedEvidencePaths = collectSavedEvidencePaths(evidenceImages, writeError);
+        // description.md は保存されたがarchive.jsonの保存に失敗した場合、description.mdとevidenceImagesで保存された画像を削除するロールバックを試みる。
+        if (savedEvidencePaths.length > 0) {
+          rollbackEvidenceCleanup = "ok";
+          for (const imagePath of savedEvidencePaths) {
+            try {
+              await onedrive.deleteItem(imagePath);
+            } catch (imageCleanupError) {
+              const reason = imageCleanupError instanceof Error ? imageCleanupError.message : String(imageCleanupError);
+              rollbackEvidenceCleanup = `failed (${reason.trim() || "unknown"})`;
+              console.warn("OneDrive rollback image cleanup skipped.", {
+                imagePath,
+                reason,
+              });
+            }
+          }
+          try {
+            await onedrive.deleteItem(`${folderPath}/imgs`);
+          } catch (imagesFolderCleanupError) {
+            const reason =
+              imagesFolderCleanupError instanceof Error
+                ? imagesFolderCleanupError.message
+                : String(imagesFolderCleanupError);
+            console.warn("OneDrive rollback images folder cleanup skipped.", {
+              folderPath,
+              reason,
+            });
+          }
+        }
         try {
           await onedrive.deleteItem(descriptionPath);
           rollbackSucceeded = true;
@@ -207,7 +254,7 @@ export async function action({ request }: ActionFunctionArgs) {
       }
       const rollbackInfo = rollbackAttempted
         ? rollbackSucceeded
-          ? `rollback=ok folderCleanup=${rollbackFolderCleanup}`
+          ? `rollback=ok evidenceCleanup=${rollbackEvidenceCleanup} folderCleanup=${rollbackFolderCleanup}`
           : `rollback=failed (${rollbackFailureReason})`
         : "rollback=not-attempted";
       throw new Error(`${raw} | partial-write: description.md saved then archive.json failed; ${rollbackInfo}`);
@@ -329,6 +376,27 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 }
 
+/* 画像URL抽出の重複排除、ダウンロード再試行、拡張子補完の契約を固定する、
+/ これらの機能を提供する関数は services/evidence-images.server.ts に切り出しているため、
+/ ここでは保存された画像のパスを収集するロジックのみを実装する
+ */
+function collectSavedEvidencePaths(
+  evidenceImages: EvidenceImageRecord[],
+  writeError: unknown,
+): string[] {
+  const paths = new Set<string>();
+  for (const record of evidenceImages) {
+    if (record.status !== "success" || !record.onedrivePath) continue;
+    paths.add(record.onedrivePath);
+  }
+  if (writeError instanceof EvidenceImagesSaveError) {
+    for (const path of writeError.savedImagePaths) {
+      if (path) paths.add(path);
+    }
+  }
+  return Array.from(paths);
+}
+
 function formatIsoForJst(date: Date): string {
   const offsetMinutes = 9 * 60;
   const offsetMs = offsetMinutes * 60 * 1000;
@@ -402,11 +470,13 @@ async function saveEvidenceImages({
   const imagesFolder = `${folderPath}/imgs`;
   const reservedNames = new Set<string>();
   const results: EvidenceImageRecord[] = [];
+  const maxImageBytes = getEvidenceImageMaxBytes();
 
   for (const sourceUrl of urls) {
     const downloaded = await downloadImageWithRetry(sourceUrl, {
       timeoutMs: 180_000,
       maxAttempts: 3,
+      maxBytes: maxImageBytes,
     });
     if ("ok" in downloaded) {
       results.push({
@@ -450,8 +520,13 @@ async function saveEvidenceImages({
       });
     } catch (error) {
       const rawMessage = error instanceof Error ? error.message : String(error);
+      // OneDrive への保存に失敗した場合、認証エラーっぽいかどうかに関わらず、まずはエラーメッセージを解析してみる。
+      // これにより、OneDrive API のエラーレスポンスの形式が変わったり、予期しないエラーが発生した場合でも、ユーザーには再認証が必要な可能性があることを伝えることができる。
       if (isOneDriveAuthLikeError(rawMessage)) {
-        throw error;
+        const savedPaths = results
+          .filter((record) => record.status === "success" && record.onedrivePath)
+          .map((record) => record.onedrivePath as string);
+        throw new EvidenceImagesSaveError(rawMessage, savedPaths);
       }
       const parsed = extractOneDriveError(rawMessage);
       results.push({
@@ -466,6 +541,23 @@ async function saveEvidenceImages({
     }
   }
   return results;
+}
+
+function getEvidenceImageMaxBytes(): number {
+  const kbRaw = process.env.ONEDRIVE_EVIDENCE_IMAGE_MAX_KB;
+  const parsedKb = Number.parseInt(kbRaw ?? "", 10);
+  if (Number.isFinite(parsedKb) && parsedKb > 0) {
+    return parsedKb * BYTES_PER_KILOBYTE;
+  }
+
+  // 後方互換: 旧bytes設定が残っている環境でも動作を維持する。
+  const bytesRaw = process.env.ONEDRIVE_EVIDENCE_IMAGE_MAX_BYTES;
+  const parsedBytes = Number.parseInt(bytesRaw ?? "", 10);
+  if (Number.isFinite(parsedBytes) && parsedBytes > 0) {
+    return parsedBytes;
+  }
+
+  return DEFAULT_EVIDENCE_IMAGE_MAX_KB * BYTES_PER_KILOBYTE;
 }
 
 // Content-Type ヘッダーから画像の拡張子を推測して、ファイル名のベース部分を生成する。

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -637,35 +637,26 @@ async function resolveEvidenceFileName({
   baseName: string;
   reservedNames: Set<string>;
 }): Promise<string> {
-  // すでに予約されているファイル名の場合は、ローカルで一意なファイル名を生成して返す。同一リクエストでのファイル名衝突を回避する。
-  if (reservedNames.has(baseName)) {
-    return allocateLocalUniqueName(baseName, reservedNames);
-  }
-
-  const basePath = `${folderPath}/${baseName}`;
-  const existing = await onedrive.getItem(basePath);
-  if (!existing) {
-    reservedNames.add(baseName);
-    return baseName;
-  }
-
-  reservedNames.add(baseName);
-  return allocateLocalUniqueName(baseName, reservedNames);
-}
-
-// ローカルで一意なファイル名を生成する。baseName の末尾に -1, -2, ... のようにインデックスを付与していき、reservedNames に存在しないファイル名が見つかるまで繰り返す。
-// インデックスは 1 から始めて最大 5000 まで試す。これ以上になると同一リクエスト内でのファイル名衝突が非常に多いと考えられるため、例外を投げる。
-function allocateLocalUniqueName(baseName: string, reservedNames: Set<string>): string {
-  const { stem, ext } = splitFileName(baseName);
-  for (let index = 1; index < 5000; index += 1) {
-    const candidate = `${stem}-${index}${ext}`;
+  // 候補ファイル名ごとに OneDrive 上の存在確認を行い、既存ファイルの上書きを防ぐ。
+  for (let index = 0; index < 5000; index += 1) {
+    const candidate = index === 0 ? baseName : buildIndexedFileName(baseName, index);
     if (reservedNames.has(candidate)) {
+      continue;
+    }
+    const existing = await onedrive.getItem(`${folderPath}/${candidate}`);
+    if (existing) {
+      reservedNames.add(candidate);
       continue;
     }
     reservedNames.add(candidate);
     return candidate;
   }
   throw new Error(`Failed to allocate image filename: ${baseName}`);
+}
+
+function buildIndexedFileName(baseName: string, index: number): string {
+  const { stem, ext } = splitFileName(baseName);
+  return `${stem}-${index}${ext}`;
 }
 
 // ファイル名を拡張子とベース名に分割する。拡張子がない場合は ext を空文字列とする。

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -418,6 +418,18 @@ async function saveEvidenceImages({
       });
       continue;
     }
+    // ダウンロードは成功したが、Content-Type が画像でない場合は保存せずに失敗とする。
+    // これにより、誤ってHTMLやJSONなどの非画像を保存してしまうリスクを減らす。
+    if (!isImageContentType(downloaded.contentType)) {
+      results.push({
+        sourceUrl,
+        status: "failed",
+        fileName: null,
+        onedrivePath: null,
+        errorReason: `UNSUPPORTED_CONTENT_TYPE: ${downloaded.contentType ?? "unknown"}`,
+      });
+      continue;
+    }
 
     try {
       const baseName = buildImageBaseName(sourceUrl, downloaded.contentType);
@@ -456,6 +468,14 @@ async function saveEvidenceImages({
   return results;
 }
 
+// Content-Type ヘッダーから画像の拡張子を推測して、ファイル名のベース部分を生成する。
+// URLのパスから拡張子が取れる場合はそれを優先する。
+function isImageContentType(contentType: string | null): boolean {
+  if (!contentType) return false;
+  const mime = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  return mime.startsWith("image/");
+}
+// 画像の拡張子を推測するための簡易マッピング。Content-Type が image/jpeg の場合は .jpg とするなど、一般的なケースをカバーする。
 async function resolveEvidenceFileName({
   onedrive,
   folderPath,
@@ -484,6 +504,7 @@ async function resolveEvidenceFileName({
   throw new Error(`Failed to allocate image filename: ${baseName}`);
 }
 
+// ファイル名を拡張子とベース名に分割する。拡張子がない場合は ext を空文字列とする。
 function splitFileName(fileName: string): { stem: string; ext: string } {
   const dotIndex = fileName.lastIndexOf(".");
   if (dotIndex <= 0 || dotIndex === fileName.length - 1) {
@@ -494,7 +515,8 @@ function splitFileName(fileName: string): { stem: string; ext: string } {
     ext: fileName.slice(dotIndex),
   };
 }
-
+// 画像URL抽出の重複排除、ダウンロード再試行、拡張子補完の契約を固定するため、
+// これらの機能を提供する関数は services/evidence-images.server.ts に切り出している。
 function summarizeEvidenceImages(records: EvidenceImageRecord[]): {
   total: number;
   success: number;

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -487,19 +487,33 @@ async function resolveEvidenceFileName({
   baseName: string;
   reservedNames: Set<string>;
 }): Promise<string> {
+  // すでに予約されているファイル名の場合は、ローカルで一意なファイル名を生成して返す。同一リクエストでのファイル名衝突を回避する。
+  if (reservedNames.has(baseName)) {
+    return allocateLocalUniqueName(baseName, reservedNames);
+  }
+
+  const basePath = `${folderPath}/${baseName}`;
+  const existing = await onedrive.getItem(basePath);
+  if (!existing) {
+    reservedNames.add(baseName);
+    return baseName;
+  }
+
+  reservedNames.add(baseName);
+  return allocateLocalUniqueName(baseName, reservedNames);
+}
+
+// ローカルで一意なファイル名を生成する。baseName の末尾に -1, -2, ... のようにインデックスを付与していき、reservedNames に存在しないファイル名が見つかるまで繰り返す。
+// インデックスは 1 から始めて最大 5000 まで試す。これ以上になると同一リクエスト内でのファイル名衝突が非常に多いと考えられるため、例外を投げる。
+function allocateLocalUniqueName(baseName: string, reservedNames: Set<string>): string {
   const { stem, ext } = splitFileName(baseName);
-  for (let index = 0; index < 5000; index += 1) {
-    const suffix = index === 0 ? "" : `-${index}`;
-    const candidate = `${stem}${suffix}${ext}`;
+  for (let index = 1; index < 5000; index += 1) {
+    const candidate = `${stem}-${index}${ext}`;
     if (reservedNames.has(candidate)) {
       continue;
     }
-    const path = `${folderPath}/${candidate}`;
-    const existing = await onedrive.getItem(path);
-    if (!existing) {
-      reservedNames.add(candidate);
-      return candidate;
-    }
+    reservedNames.add(candidate);
+    return candidate;
   }
   throw new Error(`Failed to allocate image filename: ${baseName}`);
 }

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -565,7 +565,14 @@ function getEvidenceImageMaxBytes(): number {
 function isImageContentType(contentType: string | null): boolean {
   if (!contentType) return false;
   const mime = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
-  return mime.startsWith("image/");
+  return (
+    mime === "image/jpeg" ||
+    mime === "image/jpg" ||
+    mime === "image/png" ||
+    mime === "image/gif" ||
+    mime === "image/webp" ||
+    mime === "image/avif"
+  );
 }
 // 画像の拡張子を推測するための簡易マッピング。Content-Type が image/jpeg の場合は .jpg とするなど、一般的なケースをカバーする。
 async function resolveEvidenceFileName({

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -15,7 +15,7 @@ import {
 } from "../services/github.server";
 import { getHttpStatus } from "../services/http-status";
 import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
-import { createOneDriveServiceFromEnv } from "../services/onedrive.server";
+import { createOneDriveServiceFromEnv, OneDriveApiError } from "../services/onedrive.server";
 // CSRFトークンの検証ユーティリティ
 import {
   buildImageBaseName,
@@ -555,7 +555,7 @@ async function saveEvidenceImages({
           .map((record) => record.onedrivePath as string);
         throw new EvidenceImagesSaveError(rawMessage, savedPaths);
       }
-      if (isOneDriveApiError(rawMessage)) {
+      if (error instanceof OneDriveApiError) {
         consecutiveOneDriveSaveFailures += 1;
         results.push({
           sourceUrl,
@@ -567,7 +567,6 @@ async function saveEvidenceImages({
         continue;
       }
       const parsed = extractOneDriveError(rawMessage);
-      consecutiveOneDriveSaveFailures = 0;
       results.push({
         sourceUrl,
         status: "failed",
@@ -580,10 +579,6 @@ async function saveEvidenceImages({
     }
   }
   return results;
-}
-
-function isOneDriveApiError(rawMessage: string): boolean {
-  return rawMessage.toLowerCase().includes("onedrive api error");
 }
 
 function getEvidenceImageMaxBytes(): number {

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -205,18 +205,29 @@ export async function action({ request }: ActionFunctionArgs) {
         const savedEvidencePaths = collectSavedEvidencePaths(evidenceImages, writeError);
         // description.md は保存されたがarchive.jsonの保存に失敗した場合、description.mdとevidenceImagesで保存された画像を削除するロールバックを試みる。
         if (savedEvidencePaths.length > 0) {
-          rollbackEvidenceCleanup = "ok";
+          let evidenceDeleteSuccessCount = 0;
+          let evidenceDeleteFailureCount = 0;
+          let lastEvidenceDeleteFailureReason = "unknown";
           for (const imagePath of savedEvidencePaths) {
             try {
               await onedrive.deleteItem(imagePath);
+              evidenceDeleteSuccessCount += 1;
             } catch (imageCleanupError) {
               const reason = imageCleanupError instanceof Error ? imageCleanupError.message : String(imageCleanupError);
-              rollbackEvidenceCleanup = `failed (${reason.trim() || "unknown"})`;
+              evidenceDeleteFailureCount += 1;
+              lastEvidenceDeleteFailureReason = reason.trim() || "unknown";
               console.warn("OneDrive rollback image cleanup skipped.", {
                 imagePath,
                 reason,
               });
             }
+          }
+          if (evidenceDeleteFailureCount === 0) {
+            rollbackEvidenceCleanup = "ok";
+          } else if (evidenceDeleteSuccessCount > 0) {
+            rollbackEvidenceCleanup = "partial";
+          } else {
+            rollbackEvidenceCleanup = `failed (${lastEvidenceDeleteFailureReason})`;
           }
           try {
             await onedrive.deleteItem(`${folderPath}/imgs`);
@@ -508,6 +519,7 @@ async function saveEvidenceImages({
       maxBytes: maxImageBytes,
     });
     if ("ok" in downloaded) {
+      consecutiveOneDriveSaveFailures = 0;
       results.push({
         sourceUrl,
         status: "failed",
@@ -520,6 +532,7 @@ async function saveEvidenceImages({
     // ダウンロードは成功したが、Content-Type が画像でない場合は保存せずに失敗とする。
     // これにより、誤ってHTMLやJSONなどの非画像を保存してしまうリスクを減らす。
     if (!isImageContentType(downloaded.contentType)) {
+      consecutiveOneDriveSaveFailures = 0;
       results.push({
         sourceUrl,
         status: "failed",

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -16,14 +16,26 @@ import {
 import { getHttpStatus } from "../services/http-status";
 import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
 import { createOneDriveServiceFromEnv } from "../services/onedrive.server";
+// CSRFトークンの検証ユーティリティ
+import {
+  buildImageBaseName,
+  downloadImageWithRetry,
+  extractUniqueImageUrls,
+} from "../services/evidence-images.server";
 import { parseChecklist } from "../services/checklist";
 import { verifyCsrfToken } from "../services/csrf.server";
 import { validatePrRefInput } from "../services/validation";
 
+// ルートハンドラーとビジネスロジックを分離するため、OneDrive への保存処理の詳細は services/evidence-images.server.ts に委譲する。
 export type ApiOneDriveUploadResponse =
   | {
       ok: true;
       folderPath: string;
+      evidenceImages: {
+        total: number;
+        success: number;
+        failed: number;
+      };
       uploaded: {
         descriptionMd: { name: string; webUrl: string };
         archiveJson: { name: string; webUrl: string };
@@ -36,6 +48,21 @@ export type ApiOneDriveUploadResponse =
       errorCode?: string;
       errorMessage?: string;
     };
+    
+/* OneDrive への保存処理中のエラーは、認証エラーかどうかに関わらず基本的には 502 として返す。
+// ただし、認証エラーと判断できる場合は 401 とする。
+// これにより、UI側で認証エラーとそれ以外のエラーを区別して適切なユーザーメッセージを表示できるようになる。
+*/
+type EvidenceImageStatus = "success" | "failed";
+
+type EvidenceImageRecord = {
+  sourceUrl: string;
+  status: EvidenceImageStatus;
+  fileName: string | null;
+  onedrivePath: string | null;
+  errorReason: string | null;
+};
+
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const validation = validatePrRefInput(formData);
@@ -108,6 +135,7 @@ export async function action({ request }: ActionFunctionArgs) {
     // description.md と archive.json の両方を保存する。description.md の保存に成功してから archive.json の保存に失敗した場合は、description.md を削除するロールバックを試みる。
     let descriptionMd: { name: string; webUrl: string } | null = null;
     let archiveJson: { name: string; webUrl: string } | null = null;
+    let evidenceImages: EvidenceImageRecord[] = [];
     // ロールバックの試行状況と結果を記録する変数。これにより、部分的に成功した状態で失敗した場合の状況を詳細にログに残せるようになる。
     let rollbackAttempted = false;
     let rollbackSucceeded = false;
@@ -117,6 +145,11 @@ export async function action({ request }: ActionFunctionArgs) {
     try {
       failureDomain = "onedrive"; // 明示的に失敗ドメインを切り替える。ここで失敗した場合はロールバックの必要はないため、以降は failureDomain を変更しない。
       descriptionMd = await onedrive.saveText(descriptionPath, pullRequest.body);
+      evidenceImages = await saveEvidenceImages({
+        markdown: pullRequest.body,
+        folderPath,
+        onedrive,
+      });
       archiveJson = await onedrive.saveText(
         archivePath,
         JSON.stringify(
@@ -136,7 +169,7 @@ export async function action({ request }: ActionFunctionArgs) {
             checklist: {
               items: checklist.items,
             },
-            evidenceImages: [],
+            evidenceImages,
           },
           null,
           2,
@@ -179,10 +212,12 @@ export async function action({ request }: ActionFunctionArgs) {
         : "rollback=not-attempted";
       throw new Error(`${raw} | partial-write: description.md saved then archive.json failed; ${rollbackInfo}`);
     }
+    const evidenceSummary = summarizeEvidenceImages(evidenceImages);
     return Response.json(
       {
         ok: true,
         folderPath,
+        evidenceImages: evidenceSummary,
         uploaded: {
           descriptionMd: { name: descriptionMd.name, webUrl: descriptionMd.webUrl },
           archiveJson: { name: archiveJson.name, webUrl: archiveJson.webUrl },
@@ -341,4 +376,142 @@ function slugifyForPath(value: string): string {
   }
 
   return result;
+}
+
+/* 
+/ 画像URL抽出の重複排除、ダウンロード再試行、拡張子補完の契約を固定するため、
+/ これらの機能を提供する関数は services/evidence-images.server.ts に切り出している。
+*/
+type EvidenceSaveDependencies = {
+  saveBinary: (path: string, content: Uint8Array, contentType?: string) => Promise<{ name: string; webUrl: string }>;
+  getItem: (path: string) => Promise<{ name: string; webUrl: string } | null>;
+};
+
+async function saveEvidenceImages({
+  markdown,
+  folderPath,
+  onedrive,
+}: {
+  markdown: string;
+  folderPath: string;
+  onedrive: EvidenceSaveDependencies;
+}): Promise<EvidenceImageRecord[]> {
+  const urls = extractUniqueImageUrls(markdown);
+  if (urls.length === 0) return [];
+
+  const imagesFolder = `${folderPath}/imgs`;
+  const reservedNames = new Set<string>();
+  const results: EvidenceImageRecord[] = [];
+
+  for (const sourceUrl of urls) {
+    const downloaded = await downloadImageWithRetry(sourceUrl, {
+      timeoutMs: 180_000,
+      maxAttempts: 3,
+    });
+    if ("ok" in downloaded) {
+      results.push({
+        sourceUrl,
+        status: "failed",
+        fileName: null,
+        onedrivePath: null,
+        errorReason: downloaded.errorReason,
+      });
+      continue;
+    }
+
+    try {
+      const baseName = buildImageBaseName(sourceUrl, downloaded.contentType);
+      const fileName = await resolveEvidenceFileName({
+        onedrive,
+        folderPath: imagesFolder,
+        baseName,
+        reservedNames,
+      });
+      const onedrivePath = `${imagesFolder}/${fileName}`;
+      await onedrive.saveBinary(onedrivePath, downloaded.bytes, downloaded.contentType ?? undefined);
+      results.push({
+        sourceUrl,
+        status: "success",
+        fileName,
+        onedrivePath,
+        errorReason: null,
+      });
+    } catch (error) {
+      const rawMessage = error instanceof Error ? error.message : String(error);
+      if (isOneDriveAuthLikeError(rawMessage)) {
+        throw error;
+      }
+      const parsed = extractOneDriveError(rawMessage);
+      results.push({
+        sourceUrl,
+        status: "failed",
+        fileName: null,
+        onedrivePath: null,
+        errorReason: parsed.code
+          ? `${parsed.code}: ${parsed.message ?? "save failed"}`
+          : parsed.message ?? rawMessage,
+      });
+    }
+  }
+  return results;
+}
+
+async function resolveEvidenceFileName({
+  onedrive,
+  folderPath,
+  baseName,
+  reservedNames,
+}: {
+  onedrive: EvidenceSaveDependencies;
+  folderPath: string;
+  baseName: string;
+  reservedNames: Set<string>;
+}): Promise<string> {
+  const { stem, ext } = splitFileName(baseName);
+  for (let index = 0; index < 5000; index += 1) {
+    const suffix = index === 0 ? "" : `-${index}`;
+    const candidate = `${stem}${suffix}${ext}`;
+    if (reservedNames.has(candidate)) {
+      continue;
+    }
+    const path = `${folderPath}/${candidate}`;
+    const existing = await onedrive.getItem(path);
+    if (!existing) {
+      reservedNames.add(candidate);
+      return candidate;
+    }
+  }
+  throw new Error(`Failed to allocate image filename: ${baseName}`);
+}
+
+function splitFileName(fileName: string): { stem: string; ext: string } {
+  const dotIndex = fileName.lastIndexOf(".");
+  if (dotIndex <= 0 || dotIndex === fileName.length - 1) {
+    return { stem: fileName, ext: "" };
+  }
+  return {
+    stem: fileName.slice(0, dotIndex),
+    ext: fileName.slice(dotIndex),
+  };
+}
+
+function summarizeEvidenceImages(records: EvidenceImageRecord[]): {
+  total: number;
+  success: number;
+  failed: number;
+} {
+  let success = 0;
+  let failed = 0;
+  for (const record of records) {
+    if (record.status === "success") {
+      success += 1;
+    } else {
+      failed += 1;
+    }
+  }
+  return {
+    total: records.length,
+    success,
+    failed,
+  };
 }

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -64,6 +64,7 @@ type EvidenceImageRecord = {
 };
 const DEFAULT_EVIDENCE_IMAGE_MAX_KB = 10 * 1024;
 const BYTES_PER_KILOBYTE = 1024;
+const DEFAULT_EVIDENCE_IMAGE_MAX_COUNT = 20;
 
 /*
 / 画像URL抽出の重複排除、ダウンロード再試行、拡張子補完の契約を固定するため、
@@ -471,8 +472,19 @@ async function saveEvidenceImages({
   const reservedNames = new Set<string>();
   const results: EvidenceImageRecord[] = [];
   const maxImageBytes = getEvidenceImageMaxBytes();
+  const maxImageCount = getEvidenceImageMaxCount();
 
-  for (const sourceUrl of urls) {
+  for (const [index, sourceUrl] of urls.entries()) {
+    if (index >= maxImageCount) {
+      results.push({
+        sourceUrl,
+        status: "failed",
+        fileName: null,
+        onedrivePath: null,
+        errorReason: "IMAGE_LIMIT_EXCEEDED",
+      });
+      continue;
+    }
     const downloaded = await downloadImageWithRetry(sourceUrl, {
       timeoutMs: 180_000,
       maxAttempts: 3,
@@ -558,6 +570,13 @@ function getEvidenceImageMaxBytes(): number {
   }
 
   return DEFAULT_EVIDENCE_IMAGE_MAX_KB * BYTES_PER_KILOBYTE;
+}
+
+function getEvidenceImageMaxCount(): number {
+  const raw = process.env.ONEDRIVE_EVIDENCE_IMAGE_MAX_COUNT;
+  const parsed = Number.parseInt(raw ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_EVIDENCE_IMAGE_MAX_COUNT;
+  return parsed;
 }
 
 // Content-Type ヘッダーから画像の拡張子を推測して、ファイル名のベース部分を生成する。

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -65,6 +65,9 @@ type EvidenceImageRecord = {
 const DEFAULT_EVIDENCE_IMAGE_MAX_KB = 10 * 1024;
 const BYTES_PER_KILOBYTE = 1024;
 const DEFAULT_EVIDENCE_IMAGE_MAX_COUNT = 20;
+const MAX_CONSECUTIVE_ONEDRIVE_SAVE_FAILURES = 2;
+const ONEDRIVE_SAVE_FAILED_REASON = "ONEDRIVE_SAVE_FAILED";
+const ONEDRIVE_SAVE_SKIPPED_REASON = "ONEDRIVE_SAVE_SKIPPED_AFTER_CONSECUTIVE_FAILURE";
 
 /*
 / 画像URL抽出の重複排除、ダウンロード再試行、拡張子補完の契約を固定するため、
@@ -473,6 +476,7 @@ async function saveEvidenceImages({
   const results: EvidenceImageRecord[] = [];
   const maxImageBytes = getEvidenceImageMaxBytes();
   const maxImageCount = getEvidenceImageMaxCount();
+  let consecutiveOneDriveSaveFailures = 0;
 
   for (const [index, sourceUrl] of urls.entries()) {
     if (index >= maxImageCount) {
@@ -482,6 +486,16 @@ async function saveEvidenceImages({
         fileName: null,
         onedrivePath: null,
         errorReason: "IMAGE_LIMIT_EXCEEDED",
+      });
+      continue;
+    }
+    if (consecutiveOneDriveSaveFailures >= MAX_CONSECUTIVE_ONEDRIVE_SAVE_FAILURES) {
+      results.push({
+        sourceUrl,
+        status: "failed",
+        fileName: null,
+        onedrivePath: null,
+        errorReason: ONEDRIVE_SAVE_SKIPPED_REASON,
       });
       continue;
     }
@@ -530,6 +544,7 @@ async function saveEvidenceImages({
         onedrivePath,
         errorReason: null,
       });
+      consecutiveOneDriveSaveFailures = 0;
     } catch (error) {
       const rawMessage = error instanceof Error ? error.message : String(error);
       // OneDrive への保存に失敗した場合、認証エラーっぽいかどうかに関わらず、まずはエラーメッセージを解析してみる。
@@ -540,7 +555,19 @@ async function saveEvidenceImages({
           .map((record) => record.onedrivePath as string);
         throw new EvidenceImagesSaveError(rawMessage, savedPaths);
       }
+      if (isOneDriveApiError(rawMessage)) {
+        consecutiveOneDriveSaveFailures += 1;
+        results.push({
+          sourceUrl,
+          status: "failed",
+          fileName: null,
+          onedrivePath: null,
+          errorReason: ONEDRIVE_SAVE_FAILED_REASON,
+        });
+        continue;
+      }
       const parsed = extractOneDriveError(rawMessage);
+      consecutiveOneDriveSaveFailures = 0;
       results.push({
         sourceUrl,
         status: "failed",
@@ -553,6 +580,10 @@ async function saveEvidenceImages({
     }
   }
   return results;
+}
+
+function isOneDriveApiError(rawMessage: string): boolean {
+  return rawMessage.toLowerCase().includes("onedrive api error");
 }
 
 function getEvidenceImageMaxBytes(): number {

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -64,7 +64,8 @@ type EvidenceImageRecord = {
 };
 const DEFAULT_EVIDENCE_IMAGE_MAX_KB = 10 * 1024;
 const BYTES_PER_KILOBYTE = 1024;
-const DEFAULT_EVIDENCE_IMAGE_MAX_COUNT = 20;
+const DEFAULT_EVIDENCE_IMAGE_MAX_COUNT = 20; // 画像の枚数が多すぎると保存処理が重くなったり、OneDrive の容量を圧迫したりする可能性があるため、上限を設ける。
+const MAX_ONEDRIVE_SIMPLE_UPLOAD_BYTES = 250 * 1024 * 1024; // Microsoft Graph 単純アップロードの上限
 const MAX_CONSECUTIVE_ONEDRIVE_SAVE_FAILURES = 2;
 const ONEDRIVE_SAVE_FAILED_REASON = "ONEDRIVE_SAVE_FAILED";
 const ONEDRIVE_SAVE_SKIPPED_REASON = "ONEDRIVE_SAVE_SKIPPED_AFTER_CONSECUTIVE_FAILURE";
@@ -585,17 +586,20 @@ function getEvidenceImageMaxBytes(): number {
   const kbRaw = process.env.ONEDRIVE_EVIDENCE_IMAGE_MAX_KB;
   const parsedKb = Number.parseInt(kbRaw ?? "", 10);
   if (Number.isFinite(parsedKb) && parsedKb > 0) {
-    return parsedKb * BYTES_PER_KILOBYTE;
+    return Math.min(parsedKb * BYTES_PER_KILOBYTE, MAX_ONEDRIVE_SIMPLE_UPLOAD_BYTES);
   }
 
   // 後方互換: 旧bytes設定が残っている環境でも動作を維持する。
   const bytesRaw = process.env.ONEDRIVE_EVIDENCE_IMAGE_MAX_BYTES;
   const parsedBytes = Number.parseInt(bytesRaw ?? "", 10);
   if (Number.isFinite(parsedBytes) && parsedBytes > 0) {
-    return parsedBytes;
+    return Math.min(parsedBytes, MAX_ONEDRIVE_SIMPLE_UPLOAD_BYTES);
   }
 
-  return DEFAULT_EVIDENCE_IMAGE_MAX_KB * BYTES_PER_KILOBYTE;
+  return Math.min(
+    DEFAULT_EVIDENCE_IMAGE_MAX_KB * BYTES_PER_KILOBYTE,
+    MAX_ONEDRIVE_SIMPLE_UPLOAD_BYTES,
+  );
 }
 
 function getEvidenceImageMaxCount(): number {

--- a/app/routes/auth.onedrive.callback.test.ts
+++ b/app/routes/auth.onedrive.callback.test.ts
@@ -2,11 +2,11 @@
  * OneDrive OAuth callback ルートのテスト
  *
  * このファイルを用意した理由:
- * - OAuth失敗時に内部エラー詳細をクライアントへ露出しないという要件を
+ * - OAuth失敗時にトップへ戻し、内部エラー詳細をクライアントへ露出しない契約を
  *   ルート単位でロックするため。
  *
  * このファイルが使われる場面:
- * - `npm run test` 実行時に、callbackのエラーレスポンスが定型文へサニタイズされることを確認するとき。
+ * - `npm run test` 実行時に、callback失敗時のリダイレクト契約を確認するとき。
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { loader } from "./auth.onedrive.callback";
@@ -47,21 +47,17 @@ describe("auth.onedrive.callback loader", () => {
     expect(body).toContain("Secure Cookie is unavailable on HTTP");
   });
 
-  it("OAuth provider errorの詳細をレスポンスへ露出しない", async () => {
+  it("OAuth provider error時はトップへリダイレクトする", async () => {
     const request = new Request(
       "https://localhost:5173/auth/onedrive/callback?error=access_denied&error_description=sensitive-details&error_codes=12345",
     );
 
     const response = await loader({ request });
-    const body = await response.text();
-
-    expect(response.status).toBe(400);
-    expect(body).toContain("OneDrive 認証に失敗しました。Connect OneDrive から再試行してください。");
-    expect(body).toContain("[codes: 12345]");
-    expect(body).not.toContain("sensitive-details");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/?onedrive=oauth_failed");
   });
 
-  it("token交換失敗時に内部詳細をレスポンスへ露出しない", async () => {
+  it("token交換失敗時はトップへリダイレクトする", async () => {
     vi.mocked(onedriveOAuthStateCookie.parse).mockResolvedValue("bind-a.nonce-1");
     vi.mocked(onedriveOAuthBindCookie.parse).mockResolvedValue("bind-a");
     vi.mocked(exchangeCodeForToken).mockRejectedValue(new Error("sensitive-token-error"));
@@ -72,14 +68,11 @@ describe("auth.onedrive.callback loader", () => {
     );
 
     const response = await loader({ request });
-    const body = await response.text();
-
-    expect(response.status).toBe(500);
-    expect(body).toBe("OneDrive 認証に失敗しました。Connect OneDrive から再試行してください。");
-    expect(body).not.toContain("sensitive-token-error");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/?onedrive=oauth_failed");
   });
 
-  it("stateとbind cookieの整合が取れない場合は400で拒否する", async () => {
+  it("stateとbind cookieの整合が取れない場合はトップへ戻す", async () => {
     vi.mocked(onedriveOAuthStateCookie.parse).mockResolvedValue("bind-a.nonce-1");
     vi.mocked(onedriveOAuthBindCookie.parse).mockResolvedValue("bind-b");
 
@@ -89,13 +82,11 @@ describe("auth.onedrive.callback loader", () => {
     );
 
     const response = await loader({ request });
-    const body = await response.text();
-
-    expect(response.status).toBe(400);
-    expect(body).toBe("Invalid OAuth state or code.");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/?onedrive=oauth_failed");
   });
 
-  it("state に区切りドットがない場合は400で拒否する", async () => {
+  it("state に区切りドットがない場合もトップへ戻す", async () => {
     vi.mocked(onedriveOAuthStateCookie.parse).mockResolvedValue("bind-a");
     vi.mocked(onedriveOAuthBindCookie.parse).mockResolvedValue("bind-a");
 
@@ -105,10 +96,8 @@ describe("auth.onedrive.callback loader", () => {
     );
 
     const response = await loader({ request });
-    const body = await response.text();
-
-    expect(response.status).toBe(400);
-    expect(body).toBe("Invalid OAuth state or code.");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/?onedrive=oauth_failed");
     expect(exchangeCodeForToken).not.toHaveBeenCalled();
   });
 });

--- a/app/routes/auth.onedrive.callback.tsx
+++ b/app/routes/auth.onedrive.callback.tsx
@@ -14,8 +14,13 @@ import {
   storeTokenForSession, // セッションIDに対応するトークンを保存する
 } from "../services/onedrive-auth.server";
 
-function buildOAuthRetryMessage(): string {
-  return "OneDrive 認証に失敗しました。Connect OneDrive から再試行してください。";
+const OAUTH_FAILED_REDIRECT_PATH = "/?onedrive=oauth_failed";
+
+async function buildOAuthFailureRedirect() {
+  const headers = new Headers();
+  headers.append("Set-Cookie", await onedriveOAuthStateCookie.serialize("", { maxAge: 0 }));
+  headers.append("Set-Cookie", await onedriveOAuthBindCookie.serialize("", { maxAge: 0 }));
+  return redirect(OAUTH_FAILED_REDIRECT_PATH, { headers });
 }
 
 // コールバックURLのローダー
@@ -41,12 +46,7 @@ export async function loader({ request }: { request: Request }) {
       errorDescription,
       errorCodes,
     });
-    return new Response(
-      errorCodes
-        ? `${buildOAuthRetryMessage()} [codes: ${errorCodes}]`
-        : buildOAuthRetryMessage(),
-      { status: 400 },
-    );
+    return buildOAuthFailureRedirect();
   }
 
   // stateの検証
@@ -81,7 +81,7 @@ export async function loader({ request }: { request: Request }) {
     !bindIdFromState ||
     bindIdFromCookie !== bindIdFromState
   ) {
-    return new Response("Invalid OAuth state or code.", { status: 400 });
+    return buildOAuthFailureRedirect();
   }
 
   // コードをトークンに交換
@@ -92,7 +92,7 @@ export async function loader({ request }: { request: Request }) {
     const message = err instanceof Error ? err.message : "Unknown error";
     // token交換失敗の詳細はサーバーログのみで扱う。
     console.error("OneDrive OAuth token exchange failed.", { message });
-    return new Response(buildOAuthRetryMessage(), { status: 500 });
+    return buildOAuthFailureRedirect();
   }
   const sessionId = crypto.randomUUID();
   storeTokenForSession(sessionId, tokenCache);

--- a/app/services/evidence-images.server.test.ts
+++ b/app/services/evidence-images.server.test.ts
@@ -78,6 +78,44 @@ describe("downloadImageWithRetry", () => {
     }
   });
 
+  it("Retry-After が極端に大きくても timeoutMs 上限で再試行する", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchFn = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          new Response("busy", {
+            status: 429,
+            headers: { "retry-after": "86400" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(new Uint8Array([1]), {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          }),
+        );
+      const resultPromise = downloadImageWithRetry("https://github.com/user-attachments/assets/retry.png", {
+        timeoutMs: 2_000,
+        maxAttempts: 2,
+        fetchFn,
+      });
+
+      await Promise.resolve();
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await resultPromise;
+      expect("ok" in result).toBe(false);
+      if ("ok" in result) return;
+      expect(result.bytes.byteLength).toBe(1);
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("タイムアウト時は TIMEOUT を返す", async () => {
     const fetchFn = vi.fn<typeof fetch>().mockImplementation(async (_url, init) => {
       await new Promise((_resolve, reject) => {

--- a/app/services/evidence-images.server.test.ts
+++ b/app/services/evidence-images.server.test.ts
@@ -269,8 +269,14 @@ describe("downloadImageWithRetry", () => {
   });
 
   it("Content-Length が上限超過なら即時に失敗する", async () => {
+    const tooLargeBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1]));
+      },
+    });
+    const cancelSpy = vi.spyOn(tooLargeBody, "cancel");
     const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(new Uint8Array([1]), {
+      new Response(tooLargeBody, {
         status: 200,
         headers: {
           "content-type": "image/png",
@@ -284,6 +290,7 @@ describe("downloadImageWithRetry", () => {
       fetchFn,
     });
     expect(result).toEqual({ ok: false, errorReason: "PAYLOAD_TOO_LARGE" });
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
   });
 
   it("Content-Length 未設定でも実バイトが上限超過なら失敗する", async () => {

--- a/app/services/evidence-images.server.test.ts
+++ b/app/services/evidence-images.server.test.ts
@@ -1,0 +1,92 @@
+/**
+ * evidence-images サービスの回帰防止テスト。
+ *
+ * このファイルを用意した理由:
+ * - 画像URL抽出の重複排除、ダウンロード再試行、拡張子補完の契約を固定し、
+ *   Issue #25 の要件回帰を防ぐため。
+ *
+ * このファイルが使われる場面:
+ * - `npm run test` で画像処理サービスの仕様を継続検証するとき。
+ */
+import { describe, expect, it, vi } from "vitest";
+import { buildImageBaseName, downloadImageWithRetry, extractUniqueImageUrls } from "./evidence-images.server";
+
+describe("extractUniqueImageUrls", () => {
+  it("Markdown画像URLを初出順で抽出し重複除去する", () => {
+    const markdown = `
+![a](https://example.com/a.png)
+![dup](https://example.com/a.png "title")
+text
+<img src="https://example.com/b.jpg" />
+![skip](/relative/path.png)
+`;
+    expect(extractUniqueImageUrls(markdown)).toEqual([
+      "https://example.com/a.png",
+      "https://example.com/b.jpg",
+    ]);
+  });
+
+  it("URLに括弧が含まれても正しく抽出する", () => {
+    const markdown = "![img](https://example.com/image_(v2).png \"sample\")";
+    expect(extractUniqueImageUrls(markdown)).toEqual(["https://example.com/image_(v2).png"]);
+  });
+
+  it("Evidence行のプレーンURL（GitHub user-attachments）を抽出する", () => {
+    const markdown = "Evidence: https://github.com/user-attachments/assets/c947f7d9-bb2b-406b-86af-f123753df131";
+    expect(extractUniqueImageUrls(markdown)).toEqual([
+      "https://github.com/user-attachments/assets/c947f7d9-bb2b-406b-86af-f123753df131",
+    ]);
+  });
+
+  it("非画像URLのプレーンリンクは抽出しない", () => {
+    const markdown = "PR: https://github.com/Shigeki-Kamimura/pr-description-collector/pull/10";
+    expect(extractUniqueImageUrls(markdown)).toEqual([]);
+  });
+});
+
+describe("downloadImageWithRetry", () => {
+  it("一時エラー後の再試行で成功する", async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("busy", { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+      );
+    const result = await downloadImageWithRetry("https://example.com/a.png", {
+      timeoutMs: 1000,
+      maxAttempts: 3,
+      fetchFn,
+    });
+    expect("ok" in result).toBe(false);
+    if ("ok" in result) return;
+    expect(result.contentType).toBe("image/png");
+    expect(Array.from(result.bytes)).toEqual([1, 2, 3]);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("タイムアウト時は TIMEOUT を返す", async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async (_url, init) => {
+      await new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+      return new Response();
+    });
+    const result = await downloadImageWithRetry("https://example.com/slow.png", {
+      timeoutMs: 1,
+      maxAttempts: 1,
+      fetchFn,
+    });
+    expect(result).toEqual({ ok: false, errorReason: "TIMEOUT" });
+  });
+});
+
+describe("buildImageBaseName", () => {
+  it("URL末尾が拡張子なしのとき content-type から補完する", () => {
+    expect(buildImageBaseName("https://example.com/path/evidence", "image/jpeg")).toBe("evidence.jpg");
+  });
+});

--- a/app/services/evidence-images.server.test.ts
+++ b/app/services/evidence-images.server.test.ts
@@ -143,6 +143,39 @@ describe("downloadImageWithRetry", () => {
     expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 
+  it("リダイレクト応答の body を解放してから追従する", async () => {
+    const redirectBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const cancelSpy = vi.spyOn(redirectBody, "cancel");
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(redirectBody, {
+          status: 302,
+          headers: {
+            location: "https://user-images.githubusercontent.com/image.png",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([7]), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+      );
+    const result = await downloadImageWithRetry("https://github.com/user-attachments/assets/redirect-cancel", {
+      maxAttempts: 1,
+      fetchFn,
+    });
+    expect("ok" in result).toBe(false);
+    if ("ok" in result) return;
+    expect(result.bytes.byteLength).toBe(1);
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("非許可ホストへのリダイレクトは BLOCKED_UNTRUSTED_HOST で拒否する", async () => {
     const fetchFn = vi
       .fn<typeof fetch>()
@@ -204,6 +237,26 @@ describe("downloadImageWithRetry", () => {
     });
     expect(result).toEqual({ ok: false, errorReason: "UNSUPPORTED_PROTOCOL" });
     expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("HTTPエラー時に response body を解放して失敗を返す", async () => {
+    const errorBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]));
+      },
+    });
+    const cancelSpy = vi.spyOn(errorBody, "cancel");
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(errorBody, {
+        status: 503,
+      }),
+    );
+    const result = await downloadImageWithRetry("https://github.com/user-attachments/assets/http-error", {
+      maxAttempts: 1,
+      fetchFn,
+    });
+    expect(result).toEqual({ ok: false, errorReason: "HTTP_503" });
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
   });
 
   it("許可ドメイン外のURLは拒否する", async () => {

--- a/app/services/evidence-images.server.test.ts
+++ b/app/services/evidence-images.server.test.ts
@@ -181,7 +181,7 @@ describe("downloadImageWithRetry", () => {
 
   it("localhost 宛てURLは SSRF ガードで拒否する", async () => {
     const fetchFn = vi.fn<typeof fetch>();
-    const result = await downloadImageWithRetry("http://localhost/internal.png", {
+    const result = await downloadImageWithRetry("https://localhost/internal.png", {
       fetchFn,
     });
     expect(result).toEqual({ ok: false, errorReason: "BLOCKED_PRIVATE_HOST" });
@@ -190,10 +190,19 @@ describe("downloadImageWithRetry", () => {
 
   it("リンクローカルIP宛てURLは SSRF ガードで拒否する", async () => {
     const fetchFn = vi.fn<typeof fetch>();
-    const result = await downloadImageWithRetry("http://169.254.169.254/latest/meta-data/", {
+    const result = await downloadImageWithRetry("https://169.254.169.254/latest/meta-data/", {
       fetchFn,
     });
     expect(result).toEqual({ ok: false, errorReason: "BLOCKED_PRIVATE_HOST" });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("http スキームは UNSUPPORTED_PROTOCOL で拒否する", async () => {
+    const fetchFn = vi.fn<typeof fetch>();
+    const result = await downloadImageWithRetry("http://github.com/user-attachments/assets/a.png", {
+      fetchFn,
+    });
+    expect(result).toEqual({ ok: false, errorReason: "UNSUPPORTED_PROTOCOL" });
     expect(fetchFn).not.toHaveBeenCalled();
   });
 

--- a/app/services/evidence-images.server.test.ts
+++ b/app/services/evidence-images.server.test.ts
@@ -83,6 +83,24 @@ describe("downloadImageWithRetry", () => {
     });
     expect(result).toEqual({ ok: false, errorReason: "TIMEOUT" });
   });
+
+  it("localhost 宛てURLは SSRF ガードで拒否する", async () => {
+    const fetchFn = vi.fn<typeof fetch>();
+    const result = await downloadImageWithRetry("http://localhost/internal.png", {
+      fetchFn,
+    });
+    expect(result).toEqual({ ok: false, errorReason: "BLOCKED_PRIVATE_HOST" });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("リンクローカルIP宛てURLは SSRF ガードで拒否する", async () => {
+    const fetchFn = vi.fn<typeof fetch>();
+    const result = await downloadImageWithRetry("http://169.254.169.254/latest/meta-data/", {
+      fetchFn,
+    });
+    expect(result).toEqual({ ok: false, errorReason: "BLOCKED_PRIVATE_HOST" });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
 });
 
 describe("buildImageBaseName", () => {

--- a/app/services/evidence-images.server.test.ts
+++ b/app/services/evidence-images.server.test.ts
@@ -255,6 +255,22 @@ describe("downloadImageWithRetry", () => {
     expect(result).toEqual({ ok: false, errorReason: "PAYLOAD_TOO_LARGE" });
   });
 
+  it("response.body が null でも実バイト上限を超えたら失敗する", async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "image/png" }),
+      body: null,
+      arrayBuffer: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3, 4, 5]).buffer),
+    } as unknown as Response);
+    const result = await downloadImageWithRetry("https://github.com/user-attachments/assets/null-body.png", {
+      maxBytes: 4,
+      maxAttempts: 1,
+      fetchFn,
+    });
+    expect(result).toEqual({ ok: false, errorReason: "PAYLOAD_TOO_LARGE" });
+  });
+
   it("サイズが上限以下なら成功する", async () => {
     const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(new Uint8Array([1, 2, 3, 4]), {

--- a/app/services/evidence-images.server.test.ts
+++ b/app/services/evidence-images.server.test.ts
@@ -116,6 +116,52 @@ describe("downloadImageWithRetry", () => {
     }
   });
 
+  it("許可ホストへのリダイレクトは追従して取得する", async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: {
+            location: "https://user-images.githubusercontent.com/image.png",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([9, 9]), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+      );
+    const result = await downloadImageWithRetry("https://github.com/user-attachments/assets/r1", {
+      maxAttempts: 1,
+      fetchFn,
+    });
+    expect("ok" in result).toBe(false);
+    if ("ok" in result) return;
+    expect(Array.from(result.bytes)).toEqual([9, 9]);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("非許可ホストへのリダイレクトは BLOCKED_UNTRUSTED_HOST で拒否する", async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: {
+            location: "https://example.com/not-allowed.png",
+          },
+        }),
+      );
+    const result = await downloadImageWithRetry("https://github.com/user-attachments/assets/r2", {
+      maxAttempts: 1,
+      fetchFn,
+    });
+    expect(result).toEqual({ ok: false, errorReason: "BLOCKED_UNTRUSTED_HOST" });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
   it("タイムアウト時は TIMEOUT を返す", async () => {
     const fetchFn = vi.fn<typeof fetch>().mockImplementation(async (_url, init) => {
       await new Promise((_resolve, reject) => {

--- a/app/services/evidence-images.server.test.ts
+++ b/app/services/evidence-images.server.test.ts
@@ -101,6 +101,66 @@ describe("downloadImageWithRetry", () => {
     expect(result).toEqual({ ok: false, errorReason: "BLOCKED_PRIVATE_HOST" });
     expect(fetchFn).not.toHaveBeenCalled();
   });
+
+  it("Content-Length が上限超過なら即時に失敗する", async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(new Uint8Array([1]), {
+        status: 200,
+        headers: {
+          "content-type": "image/png",
+          "content-length": String(11),
+        },
+      }),
+    );
+    const result = await downloadImageWithRetry("https://example.com/large.png", {
+      maxBytes: 10,
+      maxAttempts: 1,
+      fetchFn,
+    });
+    expect(result).toEqual({ ok: false, errorReason: "PAYLOAD_TOO_LARGE" });
+  });
+
+  it("Content-Length 未設定でも実バイトが上限超過なら失敗する", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3, 4, 5, 6]));
+        controller.enqueue(new Uint8Array([7, 8, 9, 10, 11]));
+        controller.close();
+      },
+    });
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(stream, {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+    const result = await downloadImageWithRetry("https://example.com/stream.png", {
+      maxBytes: 10,
+      maxAttempts: 1,
+      fetchFn,
+    });
+    expect(result).toEqual({ ok: false, errorReason: "PAYLOAD_TOO_LARGE" });
+  });
+
+  it("サイズが上限以下なら成功する", async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3, 4]), {
+        status: 200,
+        headers: {
+          "content-type": "image/png",
+          "content-length": "4",
+        },
+      }),
+    );
+    const result = await downloadImageWithRetry("https://example.com/small.png", {
+      maxBytes: 4,
+      maxAttempts: 1,
+      fetchFn,
+    });
+    expect("ok" in result).toBe(false);
+    if ("ok" in result) return;
+    expect(result.bytes.byteLength).toBe(4);
+  });
 });
 
 describe("buildImageBaseName", () => {

--- a/app/services/evidence-images.server.test.ts
+++ b/app/services/evidence-images.server.test.ts
@@ -55,7 +55,7 @@ describe("downloadImageWithRetry", () => {
           headers: { "content-type": "image/png" },
         }),
       );
-    const result = await downloadImageWithRetry("https://example.com/a.png", {
+    const result = await downloadImageWithRetry("https://github.com/user-attachments/assets/a.png", {
       timeoutMs: 1000,
       maxAttempts: 3,
       fetchFn,
@@ -76,7 +76,7 @@ describe("downloadImageWithRetry", () => {
       });
       return new Response();
     });
-    const result = await downloadImageWithRetry("https://example.com/slow.png", {
+    const result = await downloadImageWithRetry("https://github.com/user-attachments/assets/slow.png", {
       timeoutMs: 1,
       maxAttempts: 1,
       fetchFn,
@@ -102,6 +102,15 @@ describe("downloadImageWithRetry", () => {
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
+  it("許可ドメイン外のURLは拒否する", async () => {
+    const fetchFn = vi.fn<typeof fetch>();
+    const result = await downloadImageWithRetry("https://example.com/a.png", {
+      fetchFn,
+    });
+    expect(result).toEqual({ ok: false, errorReason: "BLOCKED_UNTRUSTED_HOST" });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
   it("Content-Length が上限超過なら即時に失敗する", async () => {
     const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(new Uint8Array([1]), {
@@ -112,7 +121,7 @@ describe("downloadImageWithRetry", () => {
         },
       }),
     );
-    const result = await downloadImageWithRetry("https://example.com/large.png", {
+    const result = await downloadImageWithRetry("https://github.com/user-attachments/assets/large.png", {
       maxBytes: 10,
       maxAttempts: 1,
       fetchFn,
@@ -134,7 +143,7 @@ describe("downloadImageWithRetry", () => {
         headers: { "content-type": "image/png" },
       }),
     );
-    const result = await downloadImageWithRetry("https://example.com/stream.png", {
+    const result = await downloadImageWithRetry("https://github.com/user-attachments/assets/stream.png", {
       maxBytes: 10,
       maxAttempts: 1,
       fetchFn,
@@ -152,7 +161,7 @@ describe("downloadImageWithRetry", () => {
         },
       }),
     );
-    const result = await downloadImageWithRetry("https://example.com/small.png", {
+    const result = await downloadImageWithRetry("https://github.com/user-attachments/assets/small.png", {
       maxBytes: 4,
       maxAttempts: 1,
       fetchFn,

--- a/app/services/evidence-images.server.test.ts
+++ b/app/services/evidence-images.server.test.ts
@@ -46,25 +46,36 @@ text
 
 describe("downloadImageWithRetry", () => {
   it("一時エラー後の再試行で成功する", async () => {
-    const fetchFn = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response("busy", { status: 503 }))
-      .mockResolvedValueOnce(
-        new Response(new Uint8Array([1, 2, 3]), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-      );
-    const result = await downloadImageWithRetry("https://github.com/user-attachments/assets/a.png", {
-      timeoutMs: 1000,
-      maxAttempts: 3,
-      fetchFn,
-    });
-    expect("ok" in result).toBe(false);
-    if ("ok" in result) return;
-    expect(result.contentType).toBe("image/png");
-    expect(Array.from(result.bytes)).toEqual([1, 2, 3]);
-    expect(fetchFn).toHaveBeenCalledTimes(2);
+    vi.useFakeTimers();
+    try {
+      const fetchFn = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response("busy", { status: 503 }))
+        .mockResolvedValueOnce(
+          new Response(new Uint8Array([1, 2, 3]), {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          }),
+        );
+      const resultPromise = downloadImageWithRetry("https://github.com/user-attachments/assets/a.png", {
+        timeoutMs: 1000,
+        maxAttempts: 3,
+        fetchFn,
+      });
+      await Promise.resolve();
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(999);
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await resultPromise;
+      expect("ok" in result).toBe(false);
+      if ("ok" in result) return;
+      expect(result.contentType).toBe("image/png");
+      expect(Array.from(result.bytes)).toEqual([1, 2, 3]);
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("タイムアウト時は TIMEOUT を返す", async () => {

--- a/app/services/evidence-images.server.test.ts
+++ b/app/services/evidence-images.server.test.ts
@@ -271,4 +271,12 @@ describe("buildImageBaseName", () => {
   it("URL末尾が拡張子なしのとき content-type から補完する", () => {
     expect(buildImageBaseName("https://example.com/path/evidence", "image/jpeg")).toBe("evidence.jpg");
   });
+
+  it("AVIF は拡張子を補完する", () => {
+    expect(buildImageBaseName("https://example.com/path/evidence", "image/avif")).toBe("evidence.avif");
+  });
+
+  it("SVG は保存対象外のため拡張子を補完しない", () => {
+    expect(buildImageBaseName("https://example.com/path/evidence", "image/svg+xml")).toBe("evidence");
+  });
 });

--- a/app/services/evidence-images.server.ts
+++ b/app/services/evidence-images.server.ts
@@ -201,7 +201,7 @@ function isLikelyImageUrl(rawUrl: string): boolean {
 }
 // EvidenceDownloadFailure の errorReason 値の例:
 // - "INVALID_URL": URLとして不正な文字列だった場合。
-// - "UNSUPPORTED_PROTOCOL": http: または https: 以外のスキームだった場合。
+// - "UNSUPPORTED_PROTOCOL": https: 以外のスキームだった場合。
 // - "BLOCKED_PRIVATE_HOST": localhost やプライベートIPアドレスなど、アクセスがブロックされるホストだった場合。
 // - "BLOCKED_UNTRUSTED_HOST": 許可ドメイン以外のホストだった場合。
 // - "TIMEOUT": ダウンロードがタイムアウトした場合。abortController を使用して fetch を中断した結果。
@@ -413,7 +413,7 @@ function getBlockedHostReason(rawUrl: string): string | null {
     return "INVALID_URL";
   }
 
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+  if (parsed.protocol !== "https:") {
     return "UNSUPPORTED_PROTOCOL";
   }
 

--- a/app/services/evidence-images.server.ts
+++ b/app/services/evidence-images.server.ts
@@ -18,6 +18,8 @@ type DownloadImageOptions = {
 
 const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
 const DEFAULT_MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024;
+const RETRY_BACKOFF_BASE_MS = 1_000;
+const RETRY_BACKOFF_MAX_MS = 10_000;
 const DEFAULT_ALLOWED_IMAGE_HOSTS = [
   "github.com",
   "user-images.githubusercontent.com",
@@ -231,8 +233,10 @@ export async function downloadImageWithRetry(
       if (!response.ok) {
         const reason = `HTTP_${response.status}`;
         const retryable = RETRYABLE_STATUS.has(response.status);
+        // リトライ可能で、かつまだリトライ回数が残っている場合は待機してから再試行する。そうでない場合は失敗として返す。
         if (retryable && attempt < maxAttempts) {
           lastReason = reason;
+          await waitBeforeRetry(attempt, response.headers.get("retry-after"));
           continue;
         }
         return { ok: false, errorReason: reason };
@@ -253,12 +257,18 @@ export async function downloadImageWithRetry(
       }
       if (error instanceof DOMException && error.name === "AbortError") {
         lastReason = "TIMEOUT";
-        if (attempt < maxAttempts) continue;
+        if (attempt < maxAttempts) {
+          await waitBeforeRetry(attempt);
+          continue;
+        }
         return { ok: false, errorReason: "TIMEOUT" };
       }
       if (error instanceof TypeError) {
         lastReason = "NETWORK_ERROR";
-        if (attempt < maxAttempts) continue;
+        if (attempt < maxAttempts) {
+          await waitBeforeRetry(attempt);
+          continue;
+        }
         return { ok: false, errorReason: "NETWORK_ERROR" };
       }
       const message = error instanceof Error ? error.message : String(error);
@@ -268,6 +278,30 @@ export async function downloadImageWithRetry(
     }
   }
   return { ok: false, errorReason: lastReason };
+}
+
+// リトライの待機時間を計算して待機する。リトライ回数に応じた指数バックオフと、サーバーからの Retry-After ヘッダーの両方を考慮する。
+async function waitBeforeRetry(attempt: number, retryAfter: string | null = null): Promise<void> {
+  const retryAfterMs = parseRetryAfterMs(retryAfter);
+  const backoffMs = Math.min(RETRY_BACKOFF_BASE_MS * attempt, RETRY_BACKOFF_MAX_MS);
+  const delayMs = retryAfterMs ?? backoffMs;
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+// Retry-After ヘッダーの値を解析して、次のリクエストまで待つべき時間をミリ秒で返す。値が無効な場合は null を返す。
+function parseRetryAfterMs(value: string | null): number | null {
+  if (!value) return null;
+  const seconds = Number.parseInt(value, 10);
+  if (Number.isFinite(seconds) && seconds > 0) {
+    return seconds * 1000;
+  }
+  const dateMs = Date.parse(value);
+  if (!Number.isFinite(dateMs)) return null;
+  const deltaMs = dateMs - Date.now();
+  if (deltaMs <= 0) return null;
+  return deltaMs;
 }
 
 function getContentLength(value: string | null): number | null {

--- a/app/services/evidence-images.server.ts
+++ b/app/services/evidence-images.server.ts
@@ -17,9 +17,11 @@ type DownloadImageOptions = {
 };
 
 const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const DEFAULT_MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024;
 const RETRY_BACKOFF_BASE_MS = 1_000;
 const RETRY_BACKOFF_MAX_MS = 10_000;
+const MAX_REDIRECTS = 5;
 const DEFAULT_ALLOWED_IMAGE_HOSTS = [
   "github.com",
   "user-images.githubusercontent.com",
@@ -226,10 +228,15 @@ export async function downloadImageWithRetry(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const response = await fetchFn(url, {
-        method: "GET",
+      const fetched = await fetchWithValidatedRedirects({
+        initialUrl: url,
+        fetchFn,
         signal: controller.signal,
       });
+      if ("ok" in fetched) {
+        return fetched;
+      }
+      const response = fetched.response;
       if (!response.ok) {
         const reason = `HTTP_${response.status}`;
         const retryable = RETRYABLE_STATUS.has(response.status);
@@ -283,6 +290,45 @@ export async function downloadImageWithRetry(
     }
   }
   return { ok: false, errorReason: lastReason };
+}
+
+async function fetchWithValidatedRedirects({
+  initialUrl,
+  fetchFn,
+  signal,
+}: {
+  initialUrl: string;
+  fetchFn: typeof fetch;
+  signal: AbortSignal;
+}): Promise<{ response: Response } | EvidenceDownloadFailure> {
+  let currentUrl = initialUrl;
+  for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount += 1) {
+    const blockedReason = getBlockedHostReason(currentUrl);
+    if (blockedReason) {
+      return { ok: false, errorReason: blockedReason };
+    }
+    const response = await fetchFn(currentUrl, {
+      method: "GET",
+      signal,
+      redirect: "manual",
+    });
+    if (!REDIRECT_STATUSES.has(response.status)) {
+      return { response };
+    }
+    const location = response.headers.get("location");
+    if (!location) {
+      return { ok: false, errorReason: `HTTP_${response.status}` };
+    }
+    if (redirectCount === MAX_REDIRECTS) {
+      return { ok: false, errorReason: "TOO_MANY_REDIRECTS" };
+    }
+    try {
+      currentUrl = new URL(location, currentUrl).toString();
+    } catch {
+      return { ok: false, errorReason: "INVALID_REDIRECT_URL" };
+    }
+  }
+  return { ok: false, errorReason: "TOO_MANY_REDIRECTS" };
 }
 
 // リトライの待機時間を計算して待機する。リトライ回数に応じた指数バックオフと、サーバーからの Retry-After ヘッダーの両方を考慮する。

--- a/app/services/evidence-images.server.ts
+++ b/app/services/evidence-images.server.ts
@@ -12,10 +12,12 @@
 type DownloadImageOptions = {
   timeoutMs: number;
   maxAttempts: number;
+  maxBytes: number;
   fetchFn?: typeof fetch;
 };
 
 const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+const DEFAULT_MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024;
 
 export type EvidenceDownloadSuccess = {
   bytes: Uint8Array;
@@ -195,12 +197,14 @@ function isLikelyImageUrl(rawUrl: string): boolean {
 // - "TIMEOUT": ダウンロードがタイムアウトした場合。abortController を使用して fetch を中断した結果。
 // - "NETWORK_ERROR": ネットワークエラーなどで fetch が失敗した場合。
 // - "HTTP_404", "HTTP_500" など: HTTPステータスコードが200以外で返ってきた場合。
+// - "PAYLOAD_TOO_LARGE": ダウンロードサイズが上限を超えた場合。
 // - "UNEXPECTED_ERROR: <message>": 上記以外の予期しないエラーが発生した場合。
 export async function downloadImageWithRetry(
   url: string,
   {
     timeoutMs = 180_000,
     maxAttempts = 3,
+    maxBytes = DEFAULT_MAX_DOWNLOAD_BYTES,
     fetchFn = fetch,
   }: Partial<DownloadImageOptions> = {},
 ): Promise<EvidenceDownloadSuccess | EvidenceDownloadFailure> {
@@ -227,13 +231,20 @@ export async function downloadImageWithRetry(
         }
         return { ok: false, errorReason: reason };
       }
+      const contentLength = getContentLength(response.headers.get("content-length"));
+      if (contentLength !== null && contentLength > maxBytes) {
+        return { ok: false, errorReason: "PAYLOAD_TOO_LARGE" };
+      }
       const contentType = response.headers.get("content-type");
-      const data = new Uint8Array(await response.arrayBuffer());
+      const data = await readResponseBytesWithLimit(response, maxBytes);
       return {
         bytes: data,
         contentType,
       };
     } catch (error) {
+      if (error instanceof Error && error.message === "PAYLOAD_TOO_LARGE") {
+        return { ok: false, errorReason: "PAYLOAD_TOO_LARGE" };
+      }
       if (error instanceof DOMException && error.name === "AbortError") {
         lastReason = "TIMEOUT";
         if (attempt < maxAttempts) continue;
@@ -251,6 +262,46 @@ export async function downloadImageWithRetry(
     }
   }
   return { ok: false, errorReason: lastReason };
+}
+
+function getContentLength(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return parsed;
+}
+
+async function readResponseBytesWithLimit(response: Response, maxBytes: number): Promise<Uint8Array> {
+  const body = response.body;
+  if (!body) return new Uint8Array(await response.arrayBuffer());
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      try {
+        await reader.cancel();
+      } catch {
+        // noop
+      }
+      throw new Error("PAYLOAD_TOO_LARGE");
+    }
+    chunks.push(value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged;
 }
 
 // URLのホストがブロック対象かどうかをチェックする。理由があれば文字列で返し、問題なければ null を返す。

--- a/app/services/evidence-images.server.ts
+++ b/app/services/evidence-images.server.ts
@@ -236,7 +236,12 @@ export async function downloadImageWithRetry(
         // リトライ可能で、かつまだリトライ回数が残っている場合は待機してから再試行する。そうでない場合は失敗として返す。
         if (retryable && attempt < maxAttempts) {
           lastReason = reason;
-          await waitBeforeRetry(attempt, response.headers.get("retry-after"));
+          // サーバーからの Retry-After ヘッダーや、リトライ回数に応じた指数バックオフを考慮して待機する。
+          await waitBeforeRetry({
+            attempt,
+            timeoutMs,
+            retryAfter: response.headers.get("retry-after"),
+          });
           continue;
         }
         return { ok: false, errorReason: reason };
@@ -258,7 +263,7 @@ export async function downloadImageWithRetry(
       if (error instanceof DOMException && error.name === "AbortError") {
         lastReason = "TIMEOUT";
         if (attempt < maxAttempts) {
-          await waitBeforeRetry(attempt);
+          await waitBeforeRetry({ attempt, timeoutMs });
           continue;
         }
         return { ok: false, errorReason: "TIMEOUT" };
@@ -266,7 +271,7 @@ export async function downloadImageWithRetry(
       if (error instanceof TypeError) {
         lastReason = "NETWORK_ERROR";
         if (attempt < maxAttempts) {
-          await waitBeforeRetry(attempt);
+          await waitBeforeRetry({ attempt, timeoutMs });
           continue;
         }
         return { ok: false, errorReason: "NETWORK_ERROR" };
@@ -281,10 +286,19 @@ export async function downloadImageWithRetry(
 }
 
 // リトライの待機時間を計算して待機する。リトライ回数に応じた指数バックオフと、サーバーからの Retry-After ヘッダーの両方を考慮する。
-async function waitBeforeRetry(attempt: number, retryAfter: string | null = null): Promise<void> {
+async function waitBeforeRetry({
+  attempt,
+  timeoutMs,
+  retryAfter = null,
+}: {
+  attempt: number;
+  timeoutMs: number;
+  retryAfter?: string | null;
+}): Promise<void> {
   const retryAfterMs = parseRetryAfterMs(retryAfter);
   const backoffMs = Math.min(RETRY_BACKOFF_BASE_MS * attempt, RETRY_BACKOFF_MAX_MS);
-  const delayMs = retryAfterMs ?? backoffMs;
+  const retryDelayMs = retryAfterMs ?? backoffMs;
+  const delayMs = Math.max(1, Math.min(retryDelayMs, RETRY_BACKOFF_MAX_MS, timeoutMs));
   await new Promise<void>((resolve) => {
     setTimeout(resolve, delayMs);
   });

--- a/app/services/evidence-images.server.ts
+++ b/app/services/evidence-images.server.ts
@@ -1,0 +1,292 @@
+/**
+ * PR本文に含まれるエビデンス画像URLの抽出・取得・保存名決定を行うサービス。
+ *
+ * このファイルを用意した理由:
+ * - 画像処理ロジック（重複排除、リトライ、タイムアウト、ファイル名決定）を
+ *   ルートから分離し、仕様変更時の影響範囲を小さく保つため。
+ *
+ * このファイルが使われる場面:
+ * - `/api/onedrive/upload` が PR本文から画像URLを処理し、
+ *   OneDrive へ保存する前段の判定・ダウンロード処理を実行するとき。
+ */
+type DownloadImageOptions = {
+  timeoutMs: number;
+  maxAttempts: number;
+  fetchFn?: typeof fetch;
+};
+
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+export type EvidenceDownloadSuccess = {
+  bytes: Uint8Array;
+  contentType: string | null;
+};
+
+export type EvidenceDownloadFailure = {
+  ok: false;
+  errorReason: string;
+};
+
+export function extractUniqueImageUrls(markdown: string): string[] {
+  if (!markdown) return [];
+
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  const pushIfNew = (rawUrl: string) => {
+    const url = rawUrl.trim();
+    if (!/^https?:\/\//i.test(url)) return;
+    if (seen.has(url)) return;
+    seen.add(url);
+    urls.push(url);
+  };
+
+  const markdownUrls = extractMarkdownImageUrls(markdown);
+  for (const url of markdownUrls) {
+    pushIfNew(url);
+  }
+  // HTMLの<img>タグからもURLを抽出する。Markdown形式でない画像が貼られている可能性があるため。
+  const htmlImgRegex = /<img\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi;
+  let imgMatch: RegExpExecArray | null = null;
+  while ((imgMatch = htmlImgRegex.exec(markdown)) !== null) {
+    pushIfNew(imgMatch[1] ?? "");
+  }
+  // Markdown形式やHTMLタグでない、単なるURLとして記載されている画像も抽出する。
+  const plainUrls = extractPlainImageUrls(markdown);
+  for (const url of plainUrls) {
+    pushIfNew(url);
+  }
+
+  return urls;
+}
+
+// Markdownの画像記法からURLを抽出する。例: ![alt](url "title") など
+function extractMarkdownImageUrls(markdown: string): string[] {
+  const urls: string[] = [];
+  let cursor = 0;
+
+  while (cursor < markdown.length) {
+    const imageStart = markdown.indexOf("![", cursor);
+    if (imageStart < 0) break;
+
+    const altClose = markdown.indexOf("]", imageStart + 2);
+    if (altClose < 0) break;
+
+    let openParen = altClose + 1;
+    while (openParen < markdown.length && /\s/.test(markdown[openParen] ?? "")) {
+      openParen += 1;
+    }
+    if (markdown[openParen] !== "(") {
+      cursor = altClose + 1;
+      continue;
+    }
+
+    const destinationStart = openParen + 1;
+    const parsed = parseMarkdownDestination(markdown, destinationStart);
+    if (!parsed) {
+      cursor = destinationStart;
+      continue;
+    }
+    urls.push(parsed.url);
+    cursor = parsed.nextIndex;
+  }
+
+  return urls;
+}
+
+function parseMarkdownDestination(
+  markdown: string,
+  start: number,
+): { url: string; nextIndex: number } | null {
+  let i = start;
+  while (i < markdown.length && /\s/.test(markdown[i] ?? "")) {
+    i += 1;
+  }
+  if (i >= markdown.length) return null;
+
+  if (markdown[i] === "<") {
+    const close = markdown.indexOf(">", i + 1);
+    if (close < 0) return null;
+    const url = markdown.slice(i + 1, close).trim();
+    const end = markdown.indexOf(")", close + 1);
+    return { url, nextIndex: end >= 0 ? end + 1 : close + 1 };
+  }
+
+  let url = "";
+  let depth = 0;
+  for (; i < markdown.length; i += 1) {
+    const char = markdown[i] ?? "";
+    if (char === "\\") {
+      const next = markdown[i + 1] ?? "";
+      if (next) {
+        url += next;
+        i += 1;
+        continue;
+      }
+    }
+    if (char === "(") {
+      depth += 1;
+      url += char;
+      continue;
+    }
+    if (char === ")") {
+      if (depth === 0) {
+        return { url: url.trim(), nextIndex: i + 1 };
+      }
+      depth -= 1;
+      url += char;
+      continue;
+    }
+    if (depth === 0 && /\s/.test(char)) {
+      const end = markdown.indexOf(")", i + 1);
+      return { url: url.trim(), nextIndex: end >= 0 ? end + 1 : i + 1 };
+    }
+    url += char;
+  }
+
+  return null;
+}
+
+function extractPlainImageUrls(markdown: string): string[] {
+  const urls: string[] = [];
+  const plainUrlRegex = /https?:\/\/[^\s<>"')]+/gi;
+  let match: RegExpExecArray | null = null;
+  while ((match = plainUrlRegex.exec(markdown)) !== null) {
+    const url = (match[0] ?? "").replace(/[.,;:!?]+$/g, "");
+    if (!url) continue;
+    if (!isLikelyImageUrl(url)) continue;
+    urls.push(url);
+  }
+  return urls;
+}
+
+function isLikelyImageUrl(rawUrl: string): boolean {
+  try {
+    const parsed = new URL(rawUrl);
+    const path = parsed.pathname.toLowerCase();
+
+    if (/\.(png|jpe?g|gif|webp|svg|bmp)(?:$|\?)/i.test(path)) {
+      return true;
+    }
+
+    // GitHubの添付画像URL（拡張子なしでも画像へリダイレクトされる）。
+    if (
+      parsed.hostname === "github.com" &&
+      path.startsWith("/user-attachments/assets/")
+    ) {
+      return true;
+    }
+
+    if (
+      parsed.hostname === "user-images.githubusercontent.com" ||
+      parsed.hostname === "github-production-user-asset-6210df.s3.amazonaws.com"
+    ) {
+      return true;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export async function downloadImageWithRetry(
+  url: string,
+  {
+    timeoutMs = 180_000,
+    maxAttempts = 3,
+    fetchFn = fetch,
+  }: Partial<DownloadImageOptions> = {},
+): Promise<EvidenceDownloadSuccess | EvidenceDownloadFailure> {
+  let lastReason = "unknown";
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetchFn(url, {
+        method: "GET",
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const reason = `HTTP_${response.status}`;
+        const retryable = RETRYABLE_STATUS.has(response.status);
+        if (retryable && attempt < maxAttempts) {
+          lastReason = reason;
+          continue;
+        }
+        return { ok: false, errorReason: reason };
+      }
+      const contentType = response.headers.get("content-type");
+      const data = new Uint8Array(await response.arrayBuffer());
+      return {
+        bytes: data,
+        contentType,
+      };
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        lastReason = "TIMEOUT";
+        if (attempt < maxAttempts) continue;
+        return { ok: false, errorReason: "TIMEOUT" };
+      }
+      if (error instanceof TypeError) {
+        lastReason = "NETWORK_ERROR";
+        if (attempt < maxAttempts) continue;
+        return { ok: false, errorReason: "NETWORK_ERROR" };
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      return { ok: false, errorReason: `UNEXPECTED_ERROR: ${message}` };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+  return { ok: false, errorReason: lastReason };
+}
+
+function normalizeFileNameSegment(value: string): string {
+  const sanitized = value
+    .normalize("NFC")
+    .replace(/[<>:"/\\|?*\u0000-\u001F]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-.\s]+|[-.\s]+$/g, "");
+  return sanitized || "image";
+}
+
+function inferExtFromContentType(contentType: string | null): string {
+  if (!contentType) return "";
+  const mime = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  switch (mime) {
+    case "image/jpeg":
+      return ".jpg";
+    case "image/png":
+      return ".png";
+    case "image/gif":
+      return ".gif";
+    case "image/webp":
+      return ".webp";
+    case "image/svg+xml":
+      return ".svg";
+    case "image/bmp":
+      return ".bmp";
+    default:
+      return "";
+  }
+}
+
+export function buildImageBaseName(url: string, contentType: string | null): string {
+  let fromUrl = "";
+  try {
+    const parsed = new URL(url);
+    const tail = parsed.pathname.split("/").filter(Boolean).at(-1) ?? "";
+    fromUrl = decodeURIComponent(tail);
+  } catch {
+    fromUrl = "";
+  }
+  const cleaned = normalizeFileNameSegment(fromUrl.replace(/[#?].*$/, ""));
+  const dot = cleaned.lastIndexOf(".");
+  if (dot > 0 && dot < cleaned.length - 1) {
+    return cleaned;
+  }
+  const ext = inferExtFromContentType(contentType);
+  return ext ? `${cleaned}${ext}` : cleaned;
+}

--- a/app/services/evidence-images.server.ts
+++ b/app/services/evidence-images.server.ts
@@ -188,7 +188,14 @@ function isLikelyImageUrl(rawUrl: string): boolean {
     return false;
   }
 }
-
+// EvidenceDownloadFailure の errorReason 値の例:
+// - "INVALID_URL": URLとして不正な文字列だった場合。
+// - "UNSUPPORTED_PROTOCOL": http: または https: 以外のスキームだった場合。
+// - "BLOCKED_PRIVATE_HOST": localhost やプライベートIPアドレスなど、アクセスがブロックされるホストだった場合。
+// - "TIMEOUT": ダウンロードがタイムアウトした場合。abortController を使用して fetch を中断した結果。
+// - "NETWORK_ERROR": ネットワークエラーなどで fetch が失敗した場合。
+// - "HTTP_404", "HTTP_500" など: HTTPステータスコードが200以外で返ってきた場合。
+// - "UNEXPECTED_ERROR: <message>": 上記以外の予期しないエラーが発生した場合。
 export async function downloadImageWithRetry(
   url: string,
   {
@@ -197,6 +204,11 @@ export async function downloadImageWithRetry(
     fetchFn = fetch,
   }: Partial<DownloadImageOptions> = {},
 ): Promise<EvidenceDownloadSuccess | EvidenceDownloadFailure> {
+  // 事前にURLのホストがブロック対象かどうかをチェックする。
+  const blockedReason = getBlockedHostReason(url);
+  if (blockedReason) {
+    return { ok: false, errorReason: blockedReason };
+  }
   let lastReason = "unknown";
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const controller = new AbortController();
@@ -239,6 +251,85 @@ export async function downloadImageWithRetry(
     }
   }
   return { ok: false, errorReason: lastReason };
+}
+
+// URLのホストがブロック対象かどうかをチェックする。理由があれば文字列で返し、問題なければ null を返す。
+function getBlockedHostReason(rawUrl: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return "INVALID_URL";
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return "UNSUPPORTED_PROTOCOL";
+  }
+
+  let host = parsed.hostname.trim().toLowerCase();
+  if (!host) return "INVALID_HOST";
+  host = stripIpv6Brackets(host);
+
+  if (host === "localhost" || host.endsWith(".localhost")) {
+    return "BLOCKED_PRIVATE_HOST";
+  }
+
+  if (isPrivateIpv4(host)) {
+    return "BLOCKED_PRIVATE_HOST";
+  }
+
+  if (isPrivateIpv6(host)) {
+    return "BLOCKED_PRIVATE_HOST";
+  }
+
+  return null;
+}
+// IPv6アドレスはURLで[ ]で括られることがあるため、括弧を取り除いて正規化する。
+function stripIpv6Brackets(host: string): string {
+  if (host.startsWith("[") && host.endsWith("]")) {
+    return host.slice(1, -1);
+  }
+  return host;
+}
+// RFC 1918, RFC 3330, RFC 6598 に定義されたプライベートIPv4アドレスを拒否する。
+function isPrivateIpv4(host: string): boolean {
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!ipv4) return false;
+  const octets = ipv4.slice(1).map((part) => Number.parseInt(part, 10));
+  if (octets.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return false;
+  const [a, b] = octets;
+
+  // loopback, private, link-local, CGNAT, unspecified を拒否する。
+  return (
+    a === 10 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    a === 0
+  );
+}
+// RFC 4193 の Unique Local Address と RFC 4291 の Link-Local Address を拒否する。
+function isPrivateIpv6(host: string): boolean {
+  const normalized = host.toLowerCase();
+  if (!normalized.includes(":")) return false;
+
+  if (normalized === "::1" || normalized === "::") return true;
+
+  if (normalized.startsWith("::ffff:")) {
+    return isPrivateIpv4(normalized.slice("::ffff:".length));
+  }
+
+  const firstSegment = normalized.split(":")[0] ?? "";
+  const first = Number.parseInt(firstSegment || "0", 16);
+  if (Number.isNaN(first)) return false;
+
+  // fc00::/7 (ULA), fe80::/10 (link-local)
+  if (first >= 0xfc00 && first <= 0xfdff) return true;
+  if (first >= 0xfe80 && first <= 0xfebf) return true;
+
+  return false;
 }
 
 function normalizeFileNameSegment(value: string): string {

--- a/app/services/evidence-images.server.ts
+++ b/app/services/evidence-images.server.ts
@@ -18,6 +18,11 @@ type DownloadImageOptions = {
 
 const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
 const DEFAULT_MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024;
+const DEFAULT_ALLOWED_IMAGE_HOSTS = [
+  "github.com",
+  "user-images.githubusercontent.com",
+  "github-production-user-asset-6210df.s3.amazonaws.com",
+];
 
 export type EvidenceDownloadSuccess = {
   bytes: Uint8Array;
@@ -194,6 +199,7 @@ function isLikelyImageUrl(rawUrl: string): boolean {
 // - "INVALID_URL": URLとして不正な文字列だった場合。
 // - "UNSUPPORTED_PROTOCOL": http: または https: 以外のスキームだった場合。
 // - "BLOCKED_PRIVATE_HOST": localhost やプライベートIPアドレスなど、アクセスがブロックされるホストだった場合。
+// - "BLOCKED_UNTRUSTED_HOST": 許可ドメイン以外のホストだった場合。
 // - "TIMEOUT": ダウンロードがタイムアウトした場合。abortController を使用して fetch を中断した結果。
 // - "NETWORK_ERROR": ネットワークエラーなどで fetch が失敗した場合。
 // - "HTTP_404", "HTTP_500" など: HTTPステータスコードが200以外で返ってきた場合。
@@ -333,7 +339,27 @@ function getBlockedHostReason(rawUrl: string): string | null {
     return "BLOCKED_PRIVATE_HOST";
   }
 
+  if (!isAllowedImageHost(host)) {
+    return "BLOCKED_UNTRUSTED_HOST";
+  }
+
   return null;
+}
+
+// ホストが許可ドメインリストにマッチするかどうかをチェックする。サブドメインも許可する。
+function isAllowedImageHost(host: string): boolean {
+  const allowedHosts = getAllowedImageHosts();
+  return allowedHosts.some((allowed) => host === allowed || host.endsWith(`.${allowed}`));
+}
+// 環境変数から許可ドメインリストを取得する。未設定や空文字の場合はデフォルトリストを返す。
+function getAllowedImageHosts(): string[] {
+  const raw = process.env.ONEDRIVE_EVIDENCE_IMAGE_ALLOWED_HOSTS;
+  if (!raw) return DEFAULT_ALLOWED_IMAGE_HOSTS;
+  const parsed = raw
+    .split(",")
+    .map((item) => item.trim().toLowerCase())
+    .filter((item) => item.length > 0);
+  return parsed.length > 0 ? parsed : DEFAULT_ALLOWED_IMAGE_HOSTS;
 }
 // IPv6アドレスはURLで[ ]で括られることがあるため、括弧を取り除いて正規化する。
 function stripIpv6Brackets(host: string): string {

--- a/app/services/evidence-images.server.ts
+++ b/app/services/evidence-images.server.ts
@@ -240,6 +240,7 @@ export async function downloadImageWithRetry(
       if (!response.ok) {
         const reason = `HTTP_${response.status}`;
         const retryable = RETRYABLE_STATUS.has(response.status);
+        await cancelResponseBodySafely(response);
         // リトライ可能で、かつまだリトライ回数が残っている場合は待機してから再試行する。そうでない場合は失敗として返す。
         if (retryable && attempt < maxAttempts) {
           lastReason = reason;
@@ -315,6 +316,8 @@ async function fetchWithValidatedRedirects({
     if (!REDIRECT_STATUSES.has(response.status)) {
       return { response };
     }
+    // リダイレクトレスポンスのボディは通常空だが、念のため安全にキャンセルしてリソースを解放する。
+    await cancelResponseBodySafely(response);
     const location = response.headers.get("location");
     if (!location) {
       return { ok: false, errorReason: `HTTP_${response.status}` };
@@ -329,6 +332,16 @@ async function fetchWithValidatedRedirects({
     }
   }
   return { ok: false, errorReason: "TOO_MANY_REDIRECTS" };
+}
+
+async function cancelResponseBodySafely(response: Response): Promise<void> {
+  const body = response.body;
+  if (!body) return;
+  try {
+    await body.cancel();
+  } catch {
+    // noop
+  }
 }
 
 // リトライの待機時間を計算して待機する。リトライ回数に応じた指数バックオフと、サーバーからの Retry-After ヘッダーの両方を考慮する。

--- a/app/services/evidence-images.server.ts
+++ b/app/services/evidence-images.server.ts
@@ -256,6 +256,7 @@ export async function downloadImageWithRetry(
       }
       const contentLength = getContentLength(response.headers.get("content-length"));
       if (contentLength !== null && contentLength > maxBytes) {
+        await cancelResponseBodySafely(response);
         return { ok: false, errorReason: "PAYLOAD_TOO_LARGE" };
       }
       const contentType = response.headers.get("content-type");

--- a/app/services/evidence-images.server.ts
+++ b/app/services/evidence-images.server.ts
@@ -519,6 +519,7 @@ function inferExtFromContentType(contentType: string | null): string {
   const mime = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
   switch (mime) {
     case "image/jpeg":
+    case "image/jpg":
       return ".jpg";
     case "image/png":
       return ".png";
@@ -526,10 +527,8 @@ function inferExtFromContentType(contentType: string | null): string {
       return ".gif";
     case "image/webp":
       return ".webp";
-    case "image/svg+xml":
-      return ".svg";
-    case "image/bmp":
-      return ".bmp";
+    case "image/avif":
+      return ".avif";
     default:
       return "";
   }

--- a/app/services/evidence-images.server.ts
+++ b/app/services/evidence-images.server.ts
@@ -373,7 +373,14 @@ function getContentLength(value: string | null): number | null {
 
 async function readResponseBytesWithLimit(response: Response, maxBytes: number): Promise<Uint8Array> {
   const body = response.body;
-  if (!body) return new Uint8Array(await response.arrayBuffer());
+  // bodyがnullの場合は、Responseオブジェクトがすでに完全に読み込まれているとみなし、arrayBufferから直接読み取る。
+  if (!body) {
+    const data = new Uint8Array(await response.arrayBuffer());
+    if (data.byteLength > maxBytes) {
+      throw new Error("PAYLOAD_TOO_LARGE");
+    }
+    return data;
+  }
 
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];

--- a/app/services/github.server.test.ts
+++ b/app/services/github.server.test.ts
@@ -81,15 +81,23 @@ describe("github service pagination", () => {
     const { createGitHubService } = await import("./github.server");
     const service = createGitHubService({ token: "token" });
     const octokit = octokitInstances[0];
-    octokit.rest.pulls.get.mockReturnValue(new Promise(() => {}) as never);
+    let capturedSignal: AbortSignal | null = null;
+    octokit.rest.pulls.get.mockImplementation((options: { request?: { signal?: AbortSignal } }) => {
+      capturedSignal = options.request?.signal ?? null;
+      return new Promise(() => {}) as never;
+    });
 
     const requestPromise = service.getPullRequest({
       repo: { owner: "octocat", name: "hello-world" },
       number: 123,
     });
 
+    expect(capturedSignal).not.toBeNull();
+    if (!capturedSignal) throw new Error("AbortSignal was not passed to Octokit request");
+    expect((capturedSignal as { aborted: boolean }).aborted).toBe(false);
     const assertion = expect(requestPromise).rejects.toThrow(/timed out after \d+ms/);
     await vi.advanceTimersByTimeAsync(180_000);
+    expect((capturedSignal as { aborted: boolean }).aborted).toBe(true);
     await assertion;
   });
 

--- a/app/services/github.server.test.ts
+++ b/app/services/github.server.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createGitHubService } from "./github.server";
 
 const octokitInstances: Array<{
   rest: { pulls: { get: ReturnType<typeof vi.fn>; listReviews: ReturnType<typeof vi.fn> } };
@@ -27,10 +26,14 @@ describe("github service pagination", () => {
   beforeEach(() => {
     octokitInstances.length = 0;
     vi.clearAllMocks();
+    vi.resetModules();
     vi.useRealTimers();
+    delete process.env.GITHUB_REQUEST_TIMEOUT_SECONDS;
+    delete process.env.GITHUB_REQUEST_TIMEOUT_MS;
   });
 
   it("getPullRequestReviews は 100件超のとき次ページも取得する", async () => {
+    const { createGitHubService } = await import("./github.server");
     const service = createGitHubService({ token: "token" });
     const octokit = octokitInstances[0];
     const listReviews = octokit.rest.pulls.listReviews;
@@ -76,6 +79,7 @@ describe("github service pagination", () => {
 
   it("GitHub API応答がない場合はタイムアウトで失敗する", async () => {
     vi.useFakeTimers();
+    const { createGitHubService } = await import("./github.server");
     const service = createGitHubService({ token: "token" });
     const octokit = octokitInstances[0];
     octokit.rest.pulls.get.mockReturnValue(new Promise(() => {}) as never);
@@ -87,6 +91,43 @@ describe("github service pagination", () => {
 
     const assertion = expect(requestPromise).rejects.toThrow(/timed out after \d+ms/);
     await vi.advanceTimersByTimeAsync(180_000);
+    await assertion;
+  });
+
+  it("GITHUB_REQUEST_TIMEOUT_SECONDS を優先して秒として解釈する", async () => {
+    vi.useFakeTimers();
+    process.env.GITHUB_REQUEST_TIMEOUT_SECONDS = "1";
+    process.env.GITHUB_REQUEST_TIMEOUT_MS = "30000";
+    const { createGitHubService } = await import("./github.server");
+    const service = createGitHubService({ token: "token" });
+    const octokit = octokitInstances[0];
+    octokit.rest.pulls.get.mockReturnValue(new Promise(() => {}) as never);
+
+    const requestPromise = service.getPullRequest({
+      repo: { owner: "octocat", name: "hello-world" },
+      number: 123,
+    });
+
+    const assertion = expect(requestPromise).rejects.toThrow("timed out after 1000ms");
+    await vi.advanceTimersByTimeAsync(1_000);
+    await assertion;
+  });
+
+  it("旧キー GITHUB_REQUEST_TIMEOUT_MS も秒として解釈する", async () => {
+    vi.useFakeTimers();
+    process.env.GITHUB_REQUEST_TIMEOUT_MS = "1";
+    const { createGitHubService } = await import("./github.server");
+    const service = createGitHubService({ token: "token" });
+    const octokit = octokitInstances[0];
+    octokit.rest.pulls.get.mockReturnValue(new Promise(() => {}) as never);
+
+    const requestPromise = service.getPullRequest({
+      repo: { owner: "octocat", name: "hello-world" },
+      number: 123,
+    });
+
+    const assertion = expect(requestPromise).rejects.toThrow("timed out after 1000ms");
+    await vi.advanceTimersByTimeAsync(1_000);
     await assertion;
   });
 });

--- a/app/services/github.server.test.ts
+++ b/app/services/github.server.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createGitHubService } from "./github.server";
 
-const octokitInstances: Array<{ rest: { pulls: { listReviews: ReturnType<typeof vi.fn> } } }> = [];
+const octokitInstances: Array<{
+  rest: { pulls: { get: ReturnType<typeof vi.fn>; listReviews: ReturnType<typeof vi.fn> } };
+}> = [];
 
 vi.mock("octokit", () => ({
   Octokit: class {
@@ -25,6 +27,7 @@ describe("github service pagination", () => {
   beforeEach(() => {
     octokitInstances.length = 0;
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it("getPullRequestReviews は 100件超のとき次ページも取得する", async () => {
@@ -69,5 +72,21 @@ describe("github service pagination", () => {
       2,
       expect.objectContaining({ per_page: 100, page: 2 }),
     );
+  });
+
+  it("GitHub API応答がない場合はタイムアウトで失敗する", async () => {
+    vi.useFakeTimers();
+    const service = createGitHubService({ token: "token" });
+    const octokit = octokitInstances[0];
+    octokit.rest.pulls.get.mockReturnValue(new Promise(() => {}) as never);
+
+    const requestPromise = service.getPullRequest({
+      repo: { owner: "octocat", name: "hello-world" },
+      number: 123,
+    });
+
+    const assertion = expect(requestPromise).rejects.toThrow(/timed out after \d+ms/);
+    await vi.advanceTimersByTimeAsync(180_000);
+    await assertion;
   });
 });

--- a/app/services/github.server.test.ts
+++ b/app/services/github.server.test.ts
@@ -29,7 +29,6 @@ describe("github service pagination", () => {
     vi.resetModules();
     vi.useRealTimers();
     delete process.env.GITHUB_REQUEST_TIMEOUT_SECONDS;
-    delete process.env.GITHUB_REQUEST_TIMEOUT_MS;
   });
 
   it("getPullRequestReviews は 100件超のとき次ページも取得する", async () => {
@@ -97,25 +96,6 @@ describe("github service pagination", () => {
   it("GITHUB_REQUEST_TIMEOUT_SECONDS を優先して秒として解釈する", async () => {
     vi.useFakeTimers();
     process.env.GITHUB_REQUEST_TIMEOUT_SECONDS = "1";
-    process.env.GITHUB_REQUEST_TIMEOUT_MS = "30000";
-    const { createGitHubService } = await import("./github.server");
-    const service = createGitHubService({ token: "token" });
-    const octokit = octokitInstances[0];
-    octokit.rest.pulls.get.mockReturnValue(new Promise(() => {}) as never);
-
-    const requestPromise = service.getPullRequest({
-      repo: { owner: "octocat", name: "hello-world" },
-      number: 123,
-    });
-
-    const assertion = expect(requestPromise).rejects.toThrow("timed out after 1000ms");
-    await vi.advanceTimersByTimeAsync(1_000);
-    await assertion;
-  });
-
-  it("旧キー GITHUB_REQUEST_TIMEOUT_MS も秒として解釈する", async () => {
-    vi.useFakeTimers();
-    process.env.GITHUB_REQUEST_TIMEOUT_MS = "1";
     const { createGitHubService } = await import("./github.server");
     const service = createGitHubService({ token: "token" });
     const octokit = octokitInstances[0];

--- a/app/services/github.server.ts
+++ b/app/services/github.server.ts
@@ -28,13 +28,20 @@ const GITHUB_REQUEST_TIMEOUT_MS = parseTimeoutSecondsToMs(
   DEFAULT_GITHUB_REQUEST_TIMEOUT_SECONDS * 1000,
 );
 
-function withRequestTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+// GitHub APIリクエストにタイムアウトを設定するユーティリティ関数
+function withRequestTimeout<T>(
+  buildPromise: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
   return new Promise<T>((resolve, reject) => {
+    // AbortControllerを使ってリクエストにタイムアウトを設定する。
+    const controller = new AbortController();
     const timeoutId = setTimeout(() => {
+      controller.abort();
       reject(new Error(`GitHub API request timed out after ${timeoutMs}ms`));
     }, timeoutMs);
 
-    promise.then(
+    buildPromise(controller.signal).then(
       (value) => {
         clearTimeout(timeoutId);
         resolve(value);
@@ -171,11 +178,13 @@ function createGitHubServiceWithOctokit(octokit: Octokit): GitHubService {
   // Octokit生成手段（PAT/GitHub Appなど）を差し替え可能にするための薄いラッパー。
   const getPullRequest = async (ref: PullRequestRef): Promise<PullRequest> => {
     const { data } = await withRequestTimeout(
-      octokit.rest.pulls.get({
-        owner: ref.repo.owner,
-        repo: ref.repo.name,
-        pull_number: ref.number,
-      }),
+      (signal) =>
+        octokit.rest.pulls.get({
+          owner: ref.repo.owner,
+          repo: ref.repo.name,
+          pull_number: ref.number,
+          request: { signal },
+        }),
       GITHUB_REQUEST_TIMEOUT_MS,
     );
     // Octokitの型をアプリ内型に変換して返す
@@ -204,13 +213,15 @@ function createGitHubServiceWithOctokit(octokit: Octokit): GitHubService {
       // GitHub APIは1回のリクエストで最大100件までしか取得できないため、ページネーションを処理する。
       for (let page = 1; ; page += 1) {
         const response = await withRequestTimeout(
-          octokit.rest.pulls.listReviews({
-            owner: ref.repo.owner,
-            repo: ref.repo.name,
-            pull_number: ref.number,
-            per_page: perPage,
-            page,
-          }),
+          (signal) =>
+            octokit.rest.pulls.listReviews({
+              owner: ref.repo.owner,
+              repo: ref.repo.name,
+              pull_number: ref.number,
+              per_page: perPage,
+              page,
+              request: { signal },
+            }),
           GITHUB_REQUEST_TIMEOUT_MS,
         );
         data.push(...response.data);

--- a/app/services/github.server.ts
+++ b/app/services/github.server.ts
@@ -16,15 +16,15 @@ import { Octokit } from "octokit";
 import { createAppAuth } from "@octokit/auth-app";
 
 const DEFAULT_GITHUB_REQUEST_TIMEOUT_SECONDS = 180;
-
-function parseTimeoutMs(value: string | undefined, fallback: number): number {
+// 環境変数から秒単位のタイムアウトをミリ秒に変換して取得するユーティリティ関数
+function parseTimeoutSecondsToMs(value: string | undefined, fallbackMs: number): number {
   const parsedSeconds = Number.parseInt(value ?? "", 10);
-  if (!Number.isFinite(parsedSeconds) || parsedSeconds <= 0) return fallback;
+  if (!Number.isFinite(parsedSeconds) || parsedSeconds <= 0) return fallbackMs;
   return parsedSeconds * 1000;
 }
 
-const GITHUB_REQUEST_TIMEOUT_MS = parseTimeoutMs(
-  process.env.GITHUB_REQUEST_TIMEOUT_MS,
+const GITHUB_REQUEST_TIMEOUT_MS = parseTimeoutSecondsToMs(
+  process.env.GITHUB_REQUEST_TIMEOUT_SECONDS ?? process.env.GITHUB_REQUEST_TIMEOUT_MS,
   DEFAULT_GITHUB_REQUEST_TIMEOUT_SECONDS * 1000,
 );
 

--- a/app/services/github.server.ts
+++ b/app/services/github.server.ts
@@ -15,6 +15,38 @@
 import { Octokit } from "octokit";
 import { createAppAuth } from "@octokit/auth-app";
 
+const DEFAULT_GITHUB_REQUEST_TIMEOUT_SECONDS = 180;
+
+function parseTimeoutMs(value: string | undefined, fallback: number): number {
+  const parsedSeconds = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsedSeconds) || parsedSeconds <= 0) return fallback;
+  return parsedSeconds * 1000;
+}
+
+const GITHUB_REQUEST_TIMEOUT_MS = parseTimeoutMs(
+  process.env.GITHUB_REQUEST_TIMEOUT_MS,
+  DEFAULT_GITHUB_REQUEST_TIMEOUT_SECONDS * 1000,
+);
+
+function withRequestTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`GitHub API request timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
+}
+
 export type GitHubAuth = {
   /** GitHub Personal Access Token または GITHUB_TOKEN */
   token: string;
@@ -138,11 +170,14 @@ export async function createGitHubServiceFromEnv(): Promise<GitHubService> {
 function createGitHubServiceWithOctokit(octokit: Octokit): GitHubService {
   // Octokit生成手段（PAT/GitHub Appなど）を差し替え可能にするための薄いラッパー。
   const getPullRequest = async (ref: PullRequestRef): Promise<PullRequest> => {
-    const { data } = await octokit.rest.pulls.get({
-      owner: ref.repo.owner,
-      repo: ref.repo.name,
-      pull_number: ref.number,
-    });
+    const { data } = await withRequestTimeout(
+      octokit.rest.pulls.get({
+        owner: ref.repo.owner,
+        repo: ref.repo.name,
+        pull_number: ref.number,
+      }),
+      GITHUB_REQUEST_TIMEOUT_MS,
+    );
     // Octokitの型をアプリ内型に変換して返す
     return {
       id: String(data.id),
@@ -168,13 +203,16 @@ function createGitHubServiceWithOctokit(octokit: Octokit): GitHubService {
       const data = [];
       // GitHub APIは1回のリクエストで最大100件までしか取得できないため、ページネーションを処理する。
       for (let page = 1; ; page += 1) {
-        const response = await octokit.rest.pulls.listReviews({
-          owner: ref.repo.owner,
-          repo: ref.repo.name,
-          pull_number: ref.number,
-          per_page: perPage,
-          page,
-        });
+        const response = await withRequestTimeout(
+          octokit.rest.pulls.listReviews({
+            owner: ref.repo.owner,
+            repo: ref.repo.name,
+            pull_number: ref.number,
+            per_page: perPage,
+            page,
+          }),
+          GITHUB_REQUEST_TIMEOUT_MS,
+        );
         data.push(...response.data);
         if (response.data.length < perPage) break;
       }

--- a/app/services/github.server.ts
+++ b/app/services/github.server.ts
@@ -24,7 +24,7 @@ function parseTimeoutSecondsToMs(value: string | undefined, fallbackMs: number):
 }
 
 const GITHUB_REQUEST_TIMEOUT_MS = parseTimeoutSecondsToMs(
-  process.env.GITHUB_REQUEST_TIMEOUT_SECONDS ?? process.env.GITHUB_REQUEST_TIMEOUT_MS,
+  process.env.GITHUB_REQUEST_TIMEOUT_SECONDS,
   DEFAULT_GITHUB_REQUEST_TIMEOUT_SECONDS * 1000,
 );
 

--- a/app/services/onedrive-auth.server.test.ts
+++ b/app/services/onedrive-auth.server.test.ts
@@ -86,7 +86,7 @@ describe("onedrive-auth refresh single-flight", () => {
       );
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(getAccessToken(request)).rejects.toThrow("timed out after 30000ms");
+    await expect(getAccessToken(request)).rejects.toThrow(/timed out after \d+ms/);
     const token = await getAccessToken(request);
 
     expect(token).toBe("new-access-token-after-timeout");

--- a/app/services/onedrive-auth.server.ts
+++ b/app/services/onedrive-auth.server.ts
@@ -18,7 +18,18 @@ const AUTH_BASE_URL = "https://login.microsoftonline.com";
 const DEFAULT_TENANT = "common";
 // OAuthスコープ
 const SCOPES = ["offline_access", "Files.ReadWrite", "User.Read"];
-const OAUTH_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_OAUTH_REQUEST_TIMEOUT_SECONDS = 180;
+
+function parseTimeoutMs(value: string | undefined, fallback: number): number {
+  const parsedSeconds = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsedSeconds) || parsedSeconds <= 0) return fallback;
+  return parsedSeconds * 1000;
+}
+
+const OAUTH_REQUEST_TIMEOUT_MS = parseTimeoutMs(
+  process.env.ONEDRIVE_OAUTH_REQUEST_TIMEOUT_MS,
+  DEFAULT_OAUTH_REQUEST_TIMEOUT_SECONDS * 1000,
+);
 
 // OAuthトークンレスポンス
 type TokenResponse = {

--- a/app/services/onedrive-auth.server.ts
+++ b/app/services/onedrive-auth.server.ts
@@ -20,14 +20,14 @@ const DEFAULT_TENANT = "common";
 const SCOPES = ["offline_access", "Files.ReadWrite", "User.Read"];
 const DEFAULT_OAUTH_REQUEST_TIMEOUT_SECONDS = 180;
 
-function parseTimeoutMs(value: string | undefined, fallback: number): number {
+function parseTimeoutSecondsToMs(value: string | undefined, fallbackMs: number): number {
   const parsedSeconds = Number.parseInt(value ?? "", 10);
-  if (!Number.isFinite(parsedSeconds) || parsedSeconds <= 0) return fallback;
+  if (!Number.isFinite(parsedSeconds) || parsedSeconds <= 0) return fallbackMs;
   return parsedSeconds * 1000;
 }
 
-const OAUTH_REQUEST_TIMEOUT_MS = parseTimeoutMs(
-  process.env.ONEDRIVE_OAUTH_REQUEST_TIMEOUT_MS,
+const OAUTH_REQUEST_TIMEOUT_MS = parseTimeoutSecondsToMs(
+  process.env.ONEDRIVE_OAUTH_REQUEST_TIMEOUT_SECONDS,
   DEFAULT_OAUTH_REQUEST_TIMEOUT_SECONDS * 1000,
 );
 

--- a/app/services/onedrive.server.test.ts
+++ b/app/services/onedrive.server.test.ts
@@ -49,4 +49,50 @@ describe("onedrive service error handling", () => {
       code: "itemNotFound",
     });
   });
+
+  it("getItem は 404 を null で返す", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { code: "itemNotFound", message: "not found" } }),
+        { status: 404, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const service = createOneDriveService({ accessToken: "token" });
+    await expect(service.getItem("missing.png")).resolves.toBeNull();
+  });
+
+  it("saveBinary は content-type を指定して保存する", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: "folder-1",
+            name: "evidence",
+            folder: {},
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: "img-1",
+            name: "image.png",
+            webUrl: "https://example.com/image.png",
+            size: 3,
+            file: { mimeType: "image/png" },
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const service = createOneDriveService({ accessToken: "token" });
+    await service.saveBinary("evidence/image.png", new Uint8Array([1, 2, 3]), "image/png");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const saveCall = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(saveCall[0]).toContain("/content");
+    expect(saveCall[1].headers).toMatchObject({ "Content-Type": "image/png" });
+  });
 });

--- a/app/services/onedrive.server.test.ts
+++ b/app/services/onedrive.server.test.ts
@@ -93,6 +93,9 @@ describe("onedrive service error handling", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const saveCall = fetchMock.mock.calls[1] as [string, RequestInit];
     expect(saveCall[0]).toContain("/content");
-    expect(saveCall[1].headers).toMatchObject({ "Content-Type": "image/png" });
+    expect(saveCall[1].headers).toMatchObject({
+      "Content-Type": "image/png",
+      "If-None-Match": "*",
+    });
   });
 });

--- a/app/services/onedrive.server.ts
+++ b/app/services/onedrive.server.ts
@@ -38,7 +38,11 @@ export type OneDriveDriveInfo = {
 export interface OneDriveService {
   /** 指定パスにテキストを保存（存在しなければ作成、あれば上書き） */
   saveText(path: string, content: string): Promise<DriveItem>;
-  /** 指定パスにバイナリを保存（存在しなければ作成、あれば上書き） */
+  /**
+   * 指定パスにバイナリを保存
+   * - 存在しなければ作成
+   * - 既存ファイルがある場合は 412 Precondition Failed となり上書きしない
+   */
   saveBinary(path: string, content: Uint8Array, contentType?: string): Promise<DriveItem>;
   /** テキストを取得 */
   getText(path: string): Promise<string>;

--- a/app/services/onedrive.server.ts
+++ b/app/services/onedrive.server.ts
@@ -38,8 +38,12 @@ export type OneDriveDriveInfo = {
 export interface OneDriveService {
   /** 指定パスにテキストを保存（存在しなければ作成、あれば上書き） */
   saveText(path: string, content: string): Promise<DriveItem>;
+  /** 指定パスにバイナリを保存（存在しなければ作成、あれば上書き） */
+  saveBinary(path: string, content: Uint8Array, contentType?: string): Promise<DriveItem>;
   /** テキストを取得 */
   getText(path: string): Promise<string>;
+  /** 指定パスのアイテム情報を取得（未存在時は null） */
+  getItem(path: string): Promise<DriveItem | null>;
   /** 指定パスのファイル/フォルダを削除 */
   deleteItem(path: string): Promise<void>;
   /** 現在のユーザー情報を取得 */
@@ -337,6 +341,32 @@ export function createOneDriveService(auth: OneDriveAuth): OneDriveService {
 
       return toDriveItem(item);
     },
+    // バイナリ保存ユーティリティ
+    async saveBinary(path: string, content: Uint8Array, contentType?: string): Promise<DriveItem> {
+      const normalized = normalizeDrivePath(path);
+      if (!normalized) throw new Error("OneDrive saveBinary: path is empty");
+
+      const parts = normalized.split("/");
+      const folderPath = parts.slice(0, -1).join("/");
+      if (folderPath) {
+        await ensureFolderPath(auth.accessToken, folderPath);
+      }
+
+      const encoded = encodeDrivePath(normalized);
+      const binary = Uint8Array.from(content);
+      const item = await graphJson<GraphDriveItem>(
+        auth.accessToken,
+        `/me/drive/root:/${encoded}:/content`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": contentType ?? "application/octet-stream",
+          },
+          body: new Blob([binary], { type: contentType ?? "application/octet-stream" }),
+        },
+      );
+      return toDriveItem(item);
+    },
     // テキスト取得ユーティリティ
     async getText(path: string): Promise<string> {
       // パス正規化とエンコード
@@ -347,6 +377,21 @@ export function createOneDriveService(auth: OneDriveAuth): OneDriveService {
       return await graphText(auth.accessToken, `/me/drive/root:/${encoded}:/content`, {
         method: "GET",
       });
+    },
+    // アイテム情報取得ユーティリティ
+    async getItem(path: string): Promise<DriveItem | null> {
+      const normalized = normalizeDrivePath(path);
+      if (!normalized) throw new Error("OneDrive getItem: path is empty");
+      const encoded = encodeDrivePath(normalized);
+      try {
+        const item = await graphJson<GraphDriveItem>(auth.accessToken, `/me/drive/root:/${encoded}:`, {
+          method: "GET",
+        });
+        return toDriveItem(item);
+      } catch (error) {
+        if (error instanceof OneDriveApiError && error.status === 404) return null;
+        throw error;
+      }
     },
     // アイテム削除ユーティリティ
     async deleteItem(path: string): Promise<void> {

--- a/app/services/onedrive.server.ts
+++ b/app/services/onedrive.server.ts
@@ -360,6 +360,7 @@ export function createOneDriveService(auth: OneDriveAuth): OneDriveService {
           method: "PUT",
           headers: {
             "Content-Type": contentType ?? "application/octet-stream",
+            "If-None-Match": "*",
           },
           body: content as unknown as BodyInit,
         },

--- a/app/services/onedrive.server.ts
+++ b/app/services/onedrive.server.ts
@@ -335,7 +335,7 @@ export function createOneDriveService(auth: OneDriveAuth): OneDriveService {
           headers: {
             "Content-Type": "text/plain; charset=utf-8",
           },
-          body: content,
+          body: content as unknown as BodyInit,
         },
       );
 
@@ -353,7 +353,6 @@ export function createOneDriveService(auth: OneDriveAuth): OneDriveService {
       }
 
       const encoded = encodeDrivePath(normalized);
-      const binary = Uint8Array.from(content);
       const item = await graphJson<GraphDriveItem>(
         auth.accessToken,
         `/me/drive/root:/${encoded}:/content`,
@@ -362,7 +361,7 @@ export function createOneDriveService(auth: OneDriveAuth): OneDriveService {
           headers: {
             "Content-Type": contentType ?? "application/octet-stream",
           },
-          body: new Blob([binary], { type: contentType ?? "application/octet-stream" }),
+          body: content as unknown as BodyInit,
         },
       );
       return toDriveItem(item);

--- a/docs/issue25-checklist.md
+++ b/docs/issue25-checklist.md
@@ -1,0 +1,52 @@
+## チェックリスト
+
+### Scope: 画像保存要件（Issue #25）
+- [x] CHK-01 `evidenceImages.status` を `success|failed` に統一
+  Result: Issue要件どおり、成功時ステータスを `success` へ修正しました。
+  Evidence: `app/routes/api.onedrive.upload.tsx`, `app/routes/api.onedrive.upload.test.ts`
+- [x] CHK-02 PR本文の画像URL抽出と重複排除
+  Result: Markdown/HTML画像URLを抽出し、同一URLは1回のみ処理する実装になっています。
+  Evidence: `app/services/evidence-images.server.ts`, `app/services/evidence-images.server.test.ts`
+- [x] CHK-03 画像保存先と衝突回避ルールの実装
+  Result: `imgs` 配下保存と同名衝突時の連番付与を実装しています。
+  Evidence: `app/routes/api.onedrive.upload.tsx`, `app/services/onedrive.server.ts`
+- [x] CHK-04 部分成功許容と失敗記録
+  Result: 一部失敗時も処理継続し、`status=failed` と `errorReason` を記録します。
+  Evidence: `app/routes/api.onedrive.upload.tsx`, `app/routes/api.onedrive.upload.test.ts`
+
+### Scope: エラー処理・品質検証
+- [x] CHK-05 OneDrive認証切れ時の中断
+  Result: 認証エラーは中断し、再認証が必要なエラーとして返却します。
+  Evidence: `app/routes/api.onedrive.upload.tsx`, `app/routes/api.onedrive.upload.test.ts`
+- [x] CHK-06 タイムアウト/リトライ実装
+  Result: 画像取得は 180秒タイムアウト・最大3回リトライを実装しています。
+  Evidence: `app/services/evidence-images.server.ts`, `app/services/evidence-images.server.test.ts`
+- [x] CHK-07 回帰テストと型検証
+  Result: 変更範囲のテストおよび型チェックを実行し、通過を確認しました。
+  Evidence: `npm run test`, `npm run typecheck`
+
+### Scope: チェックリスト運用整合
+- [x] CHK-08 チェックリスト定義の矛盾解消（不足あり2）
+  Result: 未達/非スコープ時の `Evidence: N/A` ルールをテンプレへ反映し整合化しました。
+  Evidence: `CHECKLIST_TEMPLATE.md`, `CHECKLIST_RULES.md`
+- [ ] CHK-09 Human Review セクションの「画像未実装」文言更新（不足あり3）
+  Result: 未達（次タスクで、実装済み状態に合わせて文言を更新する必要があります）。
+  Evidence: N/A
+
+### Scope: Out of Scope
+- [ ] CHK-10 UI仕様・表示仕様の見直し
+  Result: 非スコープ
+  Evidence: N/A
+
+### Scope: Review Operations / Evidence（Human Review）
+- [ ] 重複指摘・既対応指摘への返信方針が反映されている
+  Result: 人間レビュー未実施のため未確認です。
+  Evidence: N/A
+- [ ] スタッフ/シニアレビューの指摘に対する採否判断と根拠が記録されている
+  Result: 人間レビュー未実施のため未確認です。
+  Evidence: N/A
+
+### Scope: Out of Scope（Human Review）
+- [ ] 人間レビュー運用の実施ログ
+  Result: 非スコープ
+  Evidence: N/A


### PR DESCRIPTION
# PR Title
feat: PR本文のエビデンス画像保存対応と保存フローUX改善

## Summary（必須）
- 何を変えたか:
  - PR本文から画像URLを抽出し、OneDrive `imgs` 配下へ保存する処理を追加しました。
  - `archive.json.evidenceImages` に保存結果（`success/failed`、`errorReason` など）を記録するようにしました。
  - 保存成功ダイアログに画像保存サマリ（成功/失敗件数）を表示し、保存中ダイアログを追加しました。
- なぜ（背景/狙い）:
  - Issue #25 の受入基準（画像保存・部分失敗許容・再認証中断・監査可能性）を満たすためです。
  - 保存時間が長いケースでもユーザーが処理中と判断できるようにするためです。
- Touch / Do NOT touch:
  - Touch:
    - `app/routes/api.onedrive.upload.tsx`
    - `app/services/evidence-images.server.ts`
    - `app/services/onedrive.server.ts`
    - `app/components/SuccessDialog.tsx`
    - `app/components/SavingDialog.tsx`
    - `app/routes/_index.tsx`
    - 関連テストファイル
  - Do NOT touch:
    - OneDrive OAuthルートや認証フロー本体の仕様
    - 既存のGitHub取得API契約

## Acceptance（Must）（必須）
- [x] PR本文の画像URLが `imgs` 配下に保存される
- [x] `archive.json.evidenceImages` に成功/失敗結果が記録される
- [x] 失敗が混在しても成功分は保存され、失敗分は `failed` と `errorReason` が残る
- [x] OneDrive認証切れ時は中断して認証エラーを返す
- [x] 画像0件でも `description.md` / `archive.json` は保存される

## Invariants（必須）
- `Get Description` は取得専用で、保存副作用を持たない
- 保存処理は `Save to OneDrive (with images)` 実行時のみ行う
- 既存のGitHub/OneDriveエラーの定型メッセージ契約を維持する

## Deferred / Non-goals（任意）
- 進捗率付きのリアルタイム進捗表示
- 画像以外の添付ファイル（PDF/Office/ZIP等）の保存（Issue #29 へ分離）

## Validation（必須）
- Commands to run（提案）:
  - [x] `npm run typecheck`
  - [x] `npm run test -- app/services/evidence-images.server.test.ts app/routes/api.onedrive.upload.test.ts app/routes/_index.action.test.ts`
- Commands run（Human）:
  - `npm run typecheck` ✅
  - `npm run test -- app/services/evidence-images.server.test.ts app/routes/api.onedrive.upload.test.ts app/routes/_index.action.test.ts` ✅
- Smoke check（UI/手動が必要な場合のみ）:
  - [x] 通常系: `Get Description (Fetch Only)` → `Save to OneDrive (with images)` で `description.md` / `archive.json` / `imgs` を保存できる
  - [x] 保存中表示: 保存中ダイアログが表示され、完了後に成功ダイアログへ遷移する
  - [x] 成功ダイアログ: 画像保存件数（成功/失敗）が表示される

## Evidence（必須）
- Logs:
  - `npm run typecheck` → ✅
  - `npm run test -- app/services/evidence-images.server.test.ts app/routes/api.onedrive.upload.test.ts app/routes/_index.action.test.ts` → ✅
- Screenshots:
  - Image 1: `PR10-Dammy/imgs` 配下へ画像が保存された画面
  - Image 2: 保存成功ダイアログ（画像件数表示あり）

## Contracts changed（変更がある場合）
- API:
  - `ApiOneDriveUploadResponse` 成功時レスポンスに `evidenceImages: { total, success, failed }` を追加
- DB / migration:
  - なし
- Events / jobs:
  - なし
- Types / schemas:
  - `evidenceImages.status` を `success | failed` で記録

## Security / Trust Boundary（変更がある場合）
- 認証:
  - OneDrive認証切れは従来どおり中断（401相当）を維持
- 認可:
  - 変更なし
- 外部入力:
  - PR本文由来URLの抽出対象を拡張（Markdown画像、`<img>`, 一部プレーンURL）
- 機微情報（PII / secrets / logs）:
  - 変更なし（内部詳細のUI露出を抑制）

## Risk / Rollback（大きい変更は必須）
- 影響範囲:
  - OneDriveアップロードAPI、画像抽出サービス、保存完了UI表示
- 失敗時の戻し方:
  - `api.onedrive.upload` の画像処理統合差分を戻せば、従来の `description.md/archive.json` 保存に戻せる
- 互換性:
  - 既存保存フローとエラー契約は維持。成功レスポンスにサマリ項目を追加したため、呼び出し側は追従済み

## Links（任意）
- Issue:
  - https://github.com/Shigeki-Kamimura/pr-description-collector/issues/25
  - https://github.com/Shigeki-Kamimura/pr-description-collector/issues/29
- PR:
  - （作成後に追記）


## チェックリスト

### Scope: タイムアウト設定の単位統一
- [x] CHK-01 GitHubタイムアウト設定を秒キーへ統一
  Result: `GITHUB_REQUEST_TIMEOUT_SECONDS` のみを参照し、旧 `GITHUB_REQUEST_TIMEOUT_MS` 参照を削除しました。
  Evidence: `app/services/github.server.ts`, `app/services/github.server.test.ts`, `.env.example`
- [x] CHK-02 OneDrive OAuthタイムアウト設定を秒キーへ統一
  Result: `ONEDRIVE_OAUTH_REQUEST_TIMEOUT_SECONDS` のみを参照し、旧 `ONEDRIVE_OAUTH_REQUEST_TIMEOUT_MS` 参照を削除しました。
  Evidence: `app/services/onedrive-auth.server.ts`, `.env.example`

### Scope: 画像取得のセキュリティ / 可用性
- [x] CHK-03 リトライ時のバックオフ導入
  Result: retryableエラー時に即時再試行せず、バックオフ待機を入れる実装へ変更しました。
  Evidence: `app/services/evidence-images.server.ts`, `app/services/evidence-images.server.test.ts`
- [x] CHK-04 Retry-After 異常値による長時間待機を防止
  Result: `Retry-After` 待機を `timeoutMs` と上限値でクランプするように修正しました。
  Evidence: `app/services/evidence-images.server.ts`, `app/services/evidence-images.server.test.ts`
- [x] CHK-05 リダイレクト先再検証（SSRFバイパス対策）
  Result: `redirect: "manual"` で3xxを捕捉し、`Location` 追従前にホスト検証を再実行するよう修正しました。
  Evidence: `app/services/evidence-images.server.ts`, `app/services/evidence-images.server.test.ts`

### Scope: 画像保存の整合性 / 安全性
- [x] CHK-06 連続OneDrive保存失敗時のサーキットブレーカー安定化
  Result: 非OneDriveエラーで失敗カウンタをリセットしないよう修正し、閾値到達で残件スキップを維持しました。
  Evidence: `app/routes/api.onedrive.upload.tsx`, `app/routes/api.onedrive.upload.test.ts`
- [x] CHK-07 OneDrive APIエラー判定の文字列依存を排除
  Result: メッセージ文字列一致ではなく `instanceof OneDriveApiError` 判定へ置換しました。
  Evidence: `app/routes/api.onedrive.upload.tsx`, `app/routes/api.onedrive.upload.test.ts`
- [x] CHK-08 単純アップロード上限（250MB）で画像サイズ設定をクランプ
  Result: `ONEDRIVE_EVIDENCE_IMAGE_MAX_KB` の過大設定時も250MB上限に丸める実装を追加しました。
  Evidence: `app/routes/api.onedrive.upload.tsx`, `app/routes/api.onedrive.upload.test.ts`, `.env.example`
- [x] CHK-09 MIMEホワイトリスト整合（拡張子推測）
  Result: `inferExtFromContentType` を保存許可MIMEと一致させ、SVG/BMP補完を削除しAVIF補完を追加しました。
  Evidence: `app/services/evidence-images.server.ts`, `app/services/evidence-images.server.test.ts`

### Scope: 検証結果
- [x] CHK-10 変更範囲テストの実行
  Result: 変更対象ファイルのユニットテストを実行し、すべて成功しました。
  Evidence: `npm -s run test -- app/routes/api.onedrive.upload.test.ts`, `npm -s run test -- app/services/evidence-images.server.test.ts`, `npm -s run test -- app/services/github.server.test.ts`, `npm -s run test -- app/services/onedrive-auth.server.test.ts`
- [x] CHK-11 型検査の実行
  Result: 型検査を実行し、エラーなしを確認しました。
  Evidence: `npm -s run typecheck`

### Scope: Out of Scope
- [ ] CHK-12 OneDrive upload session（分割アップロード）対応
  Result: 非スコープ
  Evidence: N/A

### Scope: Review Operations / Evidence（Human Review）
- [ ] 重複指摘・既対応指摘への返信方針が反映されている
  Result: 人間レビュー最終反映は未完了です。
  Evidence: N/A
- [ ] スタッフ/シニアレビューの指摘に対する採否判断と根拠が記録されている
  Result: 人間レビュー最終反映は未完了です。
  Evidence: N/A

### Scope: Out of Scope（Human Review）
- [ ] 人間レビュー運用の実施ログ
  Result: 非スコープ
  Evidence: N/A
