### PR TITLE
Issue38-redis-token-store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,14 +24,13 @@ GITHUB_TOKEN=
 # Cookie署名用（必須）
 # 本番は十分に長いランダム文字列を設定
 SESSION_SECRET=
+# OneDrive OAuth セッションストア（必須）
+# 例: REDIS_URL=redis://localhost:6379/0
+REDIS_URL=
+# Redis 接続/コマンドのタイムアウト（ミリ秒、任意。デフォルト: 3000）
+# REDIS_TIMEOUT_MS=3000
 # 開発環境で未設定の場合は固定の開発用secretへフォールバックしますが、明示設定を推奨
 # 例: SESSION_SECRET=dev-local-session-secret-change-me
-# メモリトークンストアの上限セッション数（任意、デフォルト: 500）
-# ONEDRIVE_TOKEN_STORE_MAX_SESSIONS=500
-# 本番でメモリ tokenStore を暫定利用する場合のみ true/1（非推奨）
-# true/1 を有効化すると、再起動・再デプロイ・スケールアウト時に OAuth セッションは全喪失します。
-# 本番では Redis / DB などの永続ストア実装を必須にしてください。
-# ONEDRIVE_ALLOW_IN_MEMORY_TOKEN_STORE_IN_PRODUCTION=false
 
 # OAuth（サーバーサイド: Authorization Code）
 # ONEDRIVE_TENANT=common or your-tenant-id

--- a/README.md
+++ b/README.md
@@ -20,18 +20,17 @@ A modern, production-ready template for building full-stack React applications u
 - GitHub: `GITHUB_TOKEN`（または `GITHUB_PAT` / `GITHUB_APP_*`）
 - OneDrive: `ONEDRIVE_ACCESS_TOKEN`（開発用・`/me/drive` を操作できるトークン）
 - OneDrive OAuth（サーバーサイド）: `ONEDRIVE_TENANT` / `ONEDRIVE_CLIENT_ID` / `ONEDRIVE_CLIENT_SECRET` / `ONEDRIVE_REDIRECT_URI`
-- OneDrive OAuth token store: `ONEDRIVE_TOKEN_STORE_MAX_SESSIONS`（任意）/ `ONEDRIVE_ALLOW_IN_MEMORY_TOKEN_STORE_IN_PRODUCTION`（非推奨の暫定フラグ）
+- OneDrive OAuth token store: `REDIS_URL`（必須）/ `REDIS_TIMEOUT_MS`（任意）
 - OneDrive 保存先: `ONEDRIVE_BASE_FOLDER`（任意）/ `ONEDRIVE_WORK_FOLDER`（任意）
 - `SESSION_SECRET` は production で必須（development 未設定時は固定フォールバックあり、明示設定推奨）
 - 開発サーバー: `DEV_SERVER_HOST` / `DEV_SERVER_PORT`（ViteはHTTPで待受。利用者アクセスはHTTPS終端を必須とする）
 - 例: [.env.example](.env.example)
 
-### OneDrive OAuth Token Store (Production Note)
+### OneDrive OAuth Token Store
 
-- 本番環境でのメモリ内 `tokenStore` 運用は非推奨です。
-- `ONEDRIVE_ALLOW_IN_MEMORY_TOKEN_STORE_IN_PRODUCTION=true` は一時回避用です。
-- メモリ運用のまま本番で再起動・再デプロイ・スケールアウトすると、OneDrive OAuth セッションは全喪失します。
-- 本番では Redis / DB などの永続ストア実装を必須にしてください。
+- OneDrive OAuth のサーバー側セッションは Redis を必須とします。
+- `REDIS_URL` 未設定または Redis 障害時は、OAuth login / callback / セッション参照 / token refresh は `503` で fail-closed になります。
+- Redis 障害は認証切れとして扱わず、一時的なシステム障害として返します。
 
 ### Installation
 
@@ -144,8 +143,7 @@ docker run \
 Notes:
 
 - `SESSION_SECRET` は production で必須です。
-- OneDrive OAuth を production で使う場合は、永続 token store 実装が必要です。
-- 一時運用でメモリ token store を使う場合のみ `ONEDRIVE_ALLOW_IN_MEMORY_TOKEN_STORE_IN_PRODUCTION=true` を明示してください。
+- OneDrive OAuth を使う場合は `REDIS_URL` が必須です。
 - `http://localhost:3000` への直アクセスは、コンテナの疎通確認用です。
 - ブラウザでの実運用確認や OneDrive OAuth は、HTTPS 終端された入口（Nginx / ingress / load balancer）配下で行ってください。
 - コンテナには `/api/health` を見る `HEALTHCHECK` を設定しています。

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -124,11 +124,30 @@
    - `/me` から保存実行者を特定できない場合（`userPrincipalName` / `displayName` ともに取得不可）は、監査性を優先して保存処理を中止し、エラーとして扱う。
    - 保存処理の開始前に `/me/drive` で OneDrive セッションの有効性を検証し、未認証時は保存処理を実行しない。
 
+4. **OneDrive OAuth / セッション管理**
+   - OneDrive OAuth のサーバー側セッション情報は Redis に保存する。
+   - Redis に保存する対象は、`sessionId` に紐づく `accessToken`、`refreshToken`、`expiresAt` とする。
+   - 本番環境では、OneDrive OAuth の認証継続性を保つため、アプリ再起動・再デプロイ・スケールアウト後も Redis 上のセッション情報を参照できること。
+   - OneDrive OAuth のサーバー側セッション情報は、本番環境でプロセスメモリのみへ保持してはならない。
+   - 同一 `sessionId` に対する access token refresh は多重実行を防止する。複数アプリインスタンス環境でも、同時 refresh による不整合を起こしてはならない。
+   - OAuth の `state` およびブラウザ整合性確認用の短期値は、署名付き Secure Cookie で保持してよい。Redis 保存は必須としない。
+   - CSRF 対策は署名付き Secure Cookie を用いた方式を維持してよく、Redis 保存は必須としない。
+   - OneDrive OAuth を利用するすべての外部公開経路は HTTPS を必須とし、HTTP では認証フローを開始・完了させない。
+   - `SESSION_SECRET` は production で必須とし、Cookie 署名の信頼境界を維持する。
+   - Redis は OneDrive OAuth のサーバー側セッションストアとして必須とする。Redis が利用不能な場合、OAuth フローは fail-closed で停止し、メモリストア等への自動 fallback は行わない。
+   - Redis 接続障害、timeout、読み書き失敗時は、OAuth 開始、callback、セッション参照、access token refresh を `503 Service Unavailable` として扱う。
+   - Redis 障害時は、ユーザーに認証切れや再認証要求として見せてはならない。UI には「一時的なシステム障害」の種別で表示し、認証エラーと明確に区別する。
+   - Redis 障害時は、中途半端な session 発行、token 保存、token refresh の部分成功を許容しない。
+   - サーバーログには Redis 障害であることを識別可能なエラー情報を残し、認証失敗ログと混同しないこと。
+
 ## 非機能要件
 - **速度**: 数十〜数百行程度の入力で即時に解析できる。 
 - **可用性**: ローカル環境で動作（Remix の SSR を前提）。 
 - **可読性**: UI は最小限でも、結果の視認性（チェック状態・行番号）が確保される。 
 - **保管性**: OneDrive 上に JSON と画像が保存されること。 
+- **セッション継続性**: OneDrive OAuth セッションは、アプリ再起動・再デプロイ・複数インスタンス構成でも継続利用できること。
+- **セキュリティ**: OneDrive OAuth を利用する外部公開経路は HTTPS を必須とし、認証系 Cookie と CSRF Cookie は Secure 属性付きで扱うこと。
+- **障害時の明確性**: Redis 障害と認証切れをユーザー向け表示およびサーバーログで明確に区別できること。
 
 ## 入出力仕様
 ### 入力
@@ -169,6 +188,9 @@
 
 ## 受け入れ基準
 - レビュー完了後、PR description の JSON と画像が OneDrive に保存される。 
+- OneDrive OAuth 利用時、Redis に保存されたサーバー側セッション情報を用いて、再起動後も認証継続できる。
+- HTTP 入口では OneDrive OAuth の login / callback を開始・完了できず、HTTPS 入口でのみ利用できる。
+- Redis 障害時、OneDrive OAuth の login / callback / セッション参照 / token refresh は `503` 系で停止し、UI では認証切れではなく一時的なシステム障害として表示される。
 
 ## 既存実装との対応
 - 解析処理は `Get Description` で行う。

--- a/app/routes/api.onedrive.archive.test.ts
+++ b/app/routes/api.onedrive.archive.test.ts
@@ -11,6 +11,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { action } from "./api.onedrive.archive";
 import { createGitHubServiceFromEnv } from "../services/github.server";
 import { createOneDriveServiceFromEnv } from "../services/onedrive.server";
+import { OAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import { validatePrRefInput } from "../services/validation";
 import { verifyCsrfToken } from "../services/csrf.server";
 
@@ -207,6 +208,27 @@ describe("api.onedrive.archive action", () => {
     );
     expect(body.errorCode).toBe("ARCHIVE_JSON_INVALID");
     expect(body.errorMessage).toBeUndefined();
+  });
+
+  it("Redis障害は503で返し、archive取得へ進まない", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    onedrive.getDriveInfo.mockRejectedValue(new OAuthSessionStoreUnavailableError("redis down"));
+
+    const response = await action({ request: buildRequest() } as never);
+    const body = (await response.json()) as {
+      ok: false;
+      error: string;
+      isAuthError: boolean;
+    };
+
+    expect(response.status).toBe(503);
+    expect(body.ok).toBe(false);
+    expect(body.isAuthError).toBe(false);
+    expect(body.error).toContain("OneDrive 認証基盤で一時障害");
+    expect(github.getPullRequest).not.toHaveBeenCalled();
+    expect(onedrive.getItem).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 
   it("archive.json の body が文字列でない場合は専用メッセージとエラーコードで502を返す", async () => {

--- a/app/routes/api.onedrive.archive.tsx
+++ b/app/routes/api.onedrive.archive.tsx
@@ -9,10 +9,12 @@
  */
 import type { ActionFunctionArgs } from "react-router";
 import { createGitHubServiceFromEnv, type PullRequestRef } from "../services/github.server";
+import { logger } from "../services/logger.server";
 import { createOneDriveServiceFromEnv } from "../services/onedrive.server";
 import { isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
 import { validatePrRefInput } from "../services/validation";
 import { verifyCsrfToken } from "../services/csrf.server";
+import { isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import { normalizeEvidenceSourceUrl } from "../services/evidence-url";
 import { signEvidenceImagePath } from "../services/evidence-image-token.server";
 import { mapWithConcurrencyLimit } from "../services/concurrency";
@@ -392,6 +394,21 @@ export async function action({ request }: ActionFunctionArgs) {
       { status: 200 },
     );
   } catch (error) {
+    if (isOAuthSessionStoreUnavailableError(error)) {
+      logger.error("OneDrive archive fetch failed due to session store outage.", {
+        message: error.message,
+      });
+      return Response.json(
+        {
+          ok: false,
+          error: "OneDrive 認証基盤で一時障害が発生しています。時間をおいて再試行してください。",
+          isAuthError: false,
+          errorCode: undefined,
+          errorMessage: undefined,
+        } satisfies ApiOneDriveArchiveResponse,
+        { status: 503 },
+      );
+    }
     const rawMessage = error instanceof Error ? error.message : String(error);
     if (error instanceof ArchiveJsonInvalidError) {
       return Response.json(

--- a/app/routes/api.onedrive.evidence-image.test.ts
+++ b/app/routes/api.onedrive.evidence-image.test.ts
@@ -10,6 +10,7 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { loader } from "./api.onedrive.evidence-image";
 import { createOneDriveServiceFromEnv, OneDriveApiError } from "../services/onedrive.server";
+import { OAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import { signEvidenceImagePath } from "../services/evidence-image-token.server";
 
 vi.mock("../services/onedrive.server", () => ({
@@ -212,5 +213,19 @@ describe("api.onedrive.evidence-image loader", () => {
     const response = await loader({ request } as never);
 
     expect(response.status).toBe(413);
+  });
+
+  it("Redis障害は503で返す", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    onedrive.getBinary.mockRejectedValue(new OAuthSessionStoreUnavailableError("redis down"));
+
+    const request = buildEvidenceRequest("project/repo/PullRequests/PR1-test/imgs/a.png");
+    const response = await loader({ request } as never);
+    const body = await response.text();
+
+    expect(response.status).toBe(503);
+    expect(body).toBe("onedrive session store unavailable");
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/app/routes/api.onedrive.evidence-image.tsx
+++ b/app/routes/api.onedrive.evidence-image.tsx
@@ -8,8 +8,10 @@
  * - チェックリストカード描画時に、archive.json の onedrivePath から画像を取得するとき。
  */
 import type { LoaderFunctionArgs } from "react-router";
+import { logger } from "../services/logger.server";
 import { createOneDriveServiceFromEnv, OneDriveApiError } from "../services/onedrive.server";
 import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
+import { isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import {
   isEvidenceImageTokenFormat,
   verifyEvidenceImagePathToken,
@@ -104,6 +106,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
       },
     });
   } catch (error) {
+    if (isOAuthSessionStoreUnavailableError(error)) {
+      logger.error("OneDrive evidence-image failed due to session store outage.", {
+        message: error.message,
+      });
+      return textResponse(503, "onedrive session store unavailable");
+    }
     if (error instanceof OneDriveApiError) {
       if (error.status === 404) {
         return textResponse(404, "evidence image not found");

--- a/app/routes/api.onedrive.session-status.test.ts
+++ b/app/routes/api.onedrive.session-status.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { loader } from "./api.onedrive.session-status";
 import { getAccessToken } from "../services/onedrive-auth.server";
 import { createOneDriveService } from "../services/onedrive.server";
+import { OAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 
 vi.mock("../services/onedrive-auth.server", () => ({
   getAccessToken: vi.fn(),
@@ -9,6 +10,17 @@ vi.mock("../services/onedrive-auth.server", () => ({
 
 vi.mock("../services/onedrive.server", () => ({
   createOneDriveService: vi.fn(),
+}));
+
+vi.mock("../services/onedrive-oauth-session.server", () => ({
+  OAuthSessionStoreUnavailableError: class OAuthSessionStoreUnavailableError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "OAuthSessionStoreUnavailableError";
+    }
+  },
+  isOAuthSessionStoreUnavailableError: (error: unknown) =>
+    error instanceof Error && error.name === "OAuthSessionStoreUnavailableError",
 }));
 
 function buildRequest(): Request {
@@ -44,6 +56,25 @@ describe("api.onedrive.session-status loader", () => {
     expect(body.error).toBe("OneDrive セッション確認に失敗しました。しばらくしてから再実行してください。");
     expect(body.errorCode).toBeUndefined();
     expect(body.errorMessage).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("Redis障害は503で一時障害として返す", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(getAccessToken).mockRejectedValue(new OAuthSessionStoreUnavailableError("redis down"));
+
+    const response = await loader({ request: buildRequest() } as never);
+    const body = (await response.json()) as {
+      ok: false;
+      isAuthError: boolean;
+      error: string;
+    };
+
+    expect(response.status).toBe(503);
+    expect(body.ok).toBe(false);
+    expect(body.isAuthError).toBe(false);
+    expect(body.error).toContain("OneDrive 認証基盤で一時障害");
     expect(errorSpy).toHaveBeenCalled();
     errorSpy.mockRestore();
   });

--- a/app/routes/api.onedrive.session-status.tsx
+++ b/app/routes/api.onedrive.session-status.tsx
@@ -9,8 +9,10 @@
  * - 失敗時は UI が分岐しやすいよう `isAuthError` を返す
  */
 import type { LoaderFunctionArgs } from "react-router";
+import { logger } from "../services/logger.server";
 import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
 import { getAccessToken } from "../services/onedrive-auth.server";
+import { isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import { createOneDriveService } from "../services/onedrive.server";
 
 export type ApiOneDriveSessionStatusResponse =
@@ -45,6 +47,19 @@ export async function loader({ request }: LoaderFunctionArgs) {
       { status: 200 },
     );
   } catch (error) {
+    if (isOAuthSessionStoreUnavailableError(error)) {
+      logger.error("OneDrive session-status failed due to session store outage.", {
+        message: error.message,
+      });
+      return Response.json(
+        {
+          ok: false,
+          error: "OneDrive 認証基盤で一時障害が発生しています。時間をおいて再試行してください。",
+          isAuthError: false,
+        } satisfies ApiOneDriveSessionStatusResponse,
+        { status: 503 },
+      );
+    }
     const rawMessage = error instanceof Error ? error.message : "Unknown error";
     const parsed = extractOneDriveError(rawMessage);
     const isAuthLike = isOneDriveAuthLikeError(rawMessage);
@@ -58,7 +73,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     if (!isAuthLike) {
       // 認証エラーの可能性が低いエラーは、内部的な詳細をログに残す。
       // これにより、ユーザーには定型のエラーメッセージのみを返しつつ、開発者は問題の診断に必要な情報を得られるようになる。
-      console.error("OneDrive session-status failed.", {
+      logger.error("OneDrive session-status failed.", {
         message: rawMessage,
         code: parsed.code,
         detail: parsed.message,

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { action } from "./api.onedrive.upload";
 import { createGitHubServiceFromEnv } from "../services/github.server";
 import { createOneDriveServiceFromEnv, OneDriveApiError } from "../services/onedrive.server";
+import { OAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import { parseChecklist } from "../services/checklist";
 import { verifyCsrfToken } from "../services/csrf.server";
 import { validatePrRefInput } from "../services/validation";
@@ -264,6 +265,27 @@ describe("api.onedrive.upload action", () => {
     expect(body.error).toBe("OneDrive 認証が切れています。再認証してから保存をやり直してください。");
     expect(body.errorCode).toBeUndefined();
     expect(body.errorMessage).toBeUndefined();
+  });
+
+  it("Redis障害は503で返し、保存処理へ進まない", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    onedrive.getDriveInfo.mockRejectedValue(new OAuthSessionStoreUnavailableError("redis down"));
+
+    const response = await action({ request: buildRequest() } as never);
+    const body = (await response.json()) as {
+      ok: false;
+      isAuthError: boolean;
+      error: string;
+    };
+
+    expect(response.status).toBe(503);
+    expect(body.ok).toBe(false);
+    expect(body.isAuthError).toBe(false);
+    expect(body.error).toContain("OneDrive 認証基盤で一時障害");
+    expect(github.getPullRequest).not.toHaveBeenCalled();
+    expect(onedrive.saveText).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 
   it("OneDrive非認証エラーは内部詳細を露出せず定型メッセージで返す", async () => {

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -13,7 +13,9 @@ import {
   type PullRequestRef,
 } from "../services/github.server";
 import { getHttpStatus } from "../services/http-status";
+import { logger } from "../services/logger.server";
 import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
+import { isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import { createOneDriveServiceFromEnv, OneDriveApiError } from "../services/onedrive.server";
 // 画像保存ユーティリティ
 import {
@@ -254,7 +256,7 @@ export async function action({ request }: ActionFunctionArgs) {
               const reason = imageCleanupError instanceof Error ? imageCleanupError.message : String(imageCleanupError);
               evidenceDeleteFailureCount += 1;
               lastEvidenceDeleteFailureReason = reason.trim() || "unknown";
-              console.warn("OneDrive rollback image cleanup skipped.", {
+              logger.warn("OneDrive rollback image cleanup skipped.", {
                 imagePath,
                 reason,
               });
@@ -279,7 +281,7 @@ export async function action({ request }: ActionFunctionArgs) {
               imagesFolderCleanupError instanceof Error
                 ? imagesFolderCleanupError.message
                 : String(imagesFolderCleanupError);
-            console.warn("OneDrive rollback images folder cleanup skipped.", {
+            logger.warn("OneDrive rollback images folder cleanup skipped.", {
               folderPath,
               reason,
             });
@@ -296,7 +298,7 @@ export async function action({ request }: ActionFunctionArgs) {
             } catch (folderCleanupError) {
               const reason = folderCleanupError instanceof Error ? folderCleanupError.message : String(folderCleanupError);
               rollbackFolderCleanup = `failed (${reason.trim() || "unknown"})`;
-              console.warn("OneDrive rollback folder cleanup skipped.", {
+              logger.warn("OneDrive rollback folder cleanup skipped.", {
                 folderPath,
                 reason,
               });
@@ -350,6 +352,19 @@ export async function action({ request }: ActionFunctionArgs) {
       { status: 200 },
     );
   } catch (error) {
+    if (isOAuthSessionStoreUnavailableError(error)) {
+      logger.error("OneDrive upload failed due to session store outage.", {
+        message: error.message,
+      });
+      return Response.json(
+        {
+          ok: false,
+          error: "OneDrive 認証基盤で一時障害が発生しています。時間をおいて再試行してください。",
+          isAuthError: false,
+        } satisfies ApiOneDriveUploadResponse,
+        { status: 503 },
+      );
+    }
     const rawMessage = error instanceof Error ? error.message : "Unknown error";
     if (failureDomain === "github") {
       const status = getHttpStatus(error);
@@ -443,7 +458,7 @@ export async function action({ request }: ActionFunctionArgs) {
       : "OneDrive への保存に失敗しました。しばらくしてから再実行してください。";
     // 認証エラーっぽい場合でも、エラーコードや詳細メッセージがない場合は定型の再認証メッセージを返す。これにより、OneDrive API のエラーレスポンスの形式が変わったり、予期しないエラーが発生した場合でも、ユーザーには再認証が必要な可能性があることを伝えることができる。
     if (!isAuthLike) {
-      console.error("OneDrive upload failed.", {
+      logger.error("OneDrive upload failed.", {
         message: rawMessage,
         code: parsed.code,
         detail: parsed.message,
@@ -863,4 +878,3 @@ async function loadExistingEvidenceBySource(
     throw error;
   }
 }
-

--- a/app/routes/auth.onedrive.callback.test.ts
+++ b/app/routes/auth.onedrive.callback.test.ts
@@ -140,4 +140,38 @@ describe("auth.onedrive.callback loader", () => {
     expect(response.headers.get("Location")).toBe("/?onedrive=oauth_failed");
     expect(exchangeCodeForToken).not.toHaveBeenCalled();
   });
+
+  it("token保存失敗時は再認証案内の503を返し、state/bind cookie をクリアする", async () => {
+    vi.mocked(ensureOAuthSessionStoreAvailable).mockResolvedValue(undefined);
+    vi.mocked(onedriveOAuthStateCookie.parse).mockResolvedValue("bind-a.nonce-1");
+    vi.mocked(onedriveOAuthBindCookie.parse).mockResolvedValue("bind-a");
+    vi.mocked(exchangeCodeForToken).mockResolvedValue({
+      accessToken: "access-token-1",
+      refreshToken: "refresh-token-1",
+      expiresAt: Date.now() + 60_000,
+    });
+    vi.mocked(persistTokenForSession).mockRejectedValue(
+      new (class OAuthSessionStoreUnavailableError extends Error {
+        constructor() {
+          super("redis down on persist");
+          this.name = "OAuthSessionStoreUnavailableError";
+        }
+      })(),
+    );
+
+    const request = new Request(
+      "https://localhost:5173/auth/onedrive/callback?code=test-code&state=bind-a.nonce-1",
+      { headers: { Cookie: "onedrive_oauth_state=stub; onedrive_oauth_bind=stub" } },
+    );
+
+    const response = await loader({ request });
+    const body = await response.text();
+
+    expect(response.status).toBe(503);
+    expect(body).toContain("Connect OneDrive から認証をやり直してください");
+    expect(exchangeCodeForToken).toHaveBeenCalledTimes(1);
+    expect(persistTokenForSession).toHaveBeenCalledTimes(1);
+    expect(onedriveOAuthStateCookie.serialize).toHaveBeenCalledWith("", { maxAge: 0 });
+    expect(onedriveOAuthBindCookie.serialize).toHaveBeenCalledWith("", { maxAge: 0 });
+  });
 });

--- a/app/routes/auth.onedrive.callback.test.ts
+++ b/app/routes/auth.onedrive.callback.test.ts
@@ -14,7 +14,9 @@ import {
   exchangeCodeForToken,
   onedriveOAuthBindCookie,
   onedriveOAuthStateCookie,
+  persistTokenForSession,
 } from "../services/onedrive-auth.server";
+import { ensureOAuthSessionStoreAvailable } from "../services/onedrive-oauth-session.server";
 
 vi.mock("../services/onedrive-auth.server", () => ({
   exchangeCodeForToken: vi.fn(),
@@ -29,7 +31,19 @@ vi.mock("../services/onedrive-auth.server", () => ({
   onedriveOAuthSessionCookie: {
     serialize: vi.fn(async () => "session=test"),
   },
-  storeTokenForSession: vi.fn(),
+  persistTokenForSession: vi.fn(),
+}));
+
+vi.mock("../services/onedrive-oauth-session.server", () => ({
+  OAuthSessionStoreUnavailableError: class OAuthSessionStoreUnavailableError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "OAuthSessionStoreUnavailableError";
+    }
+  },
+  ensureOAuthSessionStoreAvailable: vi.fn(async () => {}),
+  isOAuthSessionStoreUnavailableError: (error: unknown) =>
+    error instanceof Error && error.name === "OAuthSessionStoreUnavailableError",
 }));
 
 describe("auth.onedrive.callback loader", () => {
@@ -70,6 +84,32 @@ describe("auth.onedrive.callback loader", () => {
     const response = await loader({ request });
     expect(response.status).toBe(302);
     expect(response.headers.get("Location")).toBe("/?onedrive=oauth_failed");
+  });
+
+  it("Redis障害時は503で停止する", async () => {
+    vi.mocked(onedriveOAuthStateCookie.parse).mockResolvedValue("bind-a.nonce-1");
+    vi.mocked(onedriveOAuthBindCookie.parse).mockResolvedValue("bind-a");
+    vi.mocked(ensureOAuthSessionStoreAvailable).mockRejectedValue(
+      new (class OAuthSessionStoreUnavailableError extends Error {
+        constructor() {
+          super("redis down");
+          this.name = "OAuthSessionStoreUnavailableError";
+        }
+      })(),
+    );
+
+    const request = new Request(
+      "https://localhost:5173/auth/onedrive/callback?code=test-code&state=bind-a.nonce-1",
+      { headers: { Cookie: "onedrive_oauth_state=stub; onedrive_oauth_bind=stub" } },
+    );
+
+    const response = await loader({ request });
+    const body = await response.text();
+
+    expect(response.status).toBe(503);
+    expect(body).toContain("OneDrive 認証基盤で一時障害");
+    expect(exchangeCodeForToken).not.toHaveBeenCalled();
+    expect(persistTokenForSession).not.toHaveBeenCalled();
   });
 
   it("stateとbind cookieの整合が取れない場合はトップへ戻す", async () => {

--- a/app/routes/auth.onedrive.callback.tsx
+++ b/app/routes/auth.onedrive.callback.tsx
@@ -6,15 +6,22 @@
 // OAuth認可コードを受け取り、アクセストークンを取得して保存する
 import { redirect } from "react-router";
 import { isHttpsRequest } from "../services/https-validation.server";
+import { logger } from "../services/logger.server";
+import {
+  ensureOAuthSessionStoreAvailable,
+  isOAuthSessionStoreUnavailableError,
+} from "../services/onedrive-oauth-session.server";
 import {
   onedriveOAuthBindCookie, // OAuth開始時バインドCookie
   exchangeCodeForToken, // OneDrive OAuthトークン交換
   onedriveOAuthStateCookie, // OAuth状態管理用Cookie
   onedriveOAuthSessionCookie, // OAuthセッションID保持用Cookie
-  storeTokenForSession, // セッションIDに対応するトークンを保存する
+  persistTokenForSession, // セッションIDに対応するトークンを保存する
 } from "../services/onedrive-auth.server";
 
 const OAUTH_FAILED_REDIRECT_PATH = "/?onedrive=oauth_failed";
+const OAUTH_INFRASTRUCTURE_ERROR_MESSAGE =
+  "OneDrive 認証基盤で一時障害が発生しています。時間をおいて再試行してください。";
 
 async function buildOAuthFailureRedirect() {
   const headers = new Headers();
@@ -41,7 +48,7 @@ export async function loader({ request }: { request: Request }) {
 
   if (error) {
     // 詳細はサーバーログに残し、クライアントには再試行可能な定型メッセージのみ返す。
-    console.warn("OneDrive OAuth callback returned an error.", {
+    logger.warn("OneDrive OAuth callback returned an error.", {
       error,
       errorDescription,
       errorCodes,
@@ -84,18 +91,47 @@ export async function loader({ request }: { request: Request }) {
     return buildOAuthFailureRedirect();
   }
 
+  try {
+    await ensureOAuthSessionStoreAvailable();
+  } catch (error) {
+    if (isOAuthSessionStoreUnavailableError(error)) {
+      logger.error("OneDrive OAuth session store failed.", {
+        message: error.message,
+      });
+      return new Response(OAUTH_INFRASTRUCTURE_ERROR_MESSAGE, { status: 503 });
+    }
+    throw error;
+  }
+
   // コードをトークンに交換
   let tokenCache: Awaited<ReturnType<typeof exchangeCodeForToken>>;
   try {
     tokenCache = await exchangeCodeForToken(code);
   } catch (err) {
+    // トークン交換失敗の原因がセッションストア障害なのかを判別し、適切なレスポンスを返す。
+    if (isOAuthSessionStoreUnavailableError(err)) {
+      logger.error("OneDrive OAuth session store failed.", {
+        message: err.message,
+      });
+      return new Response(OAUTH_INFRASTRUCTURE_ERROR_MESSAGE, { status: 503 });
+    }
     const message = err instanceof Error ? err.message : "Unknown error";
     // token交換失敗の詳細はサーバーログのみで扱う。
-    console.error("OneDrive OAuth token exchange failed.", { message });
+    logger.error("OneDrive OAuth token exchange failed.", { message });
     return buildOAuthFailureRedirect();
   }
   const sessionId = crypto.randomUUID();
-  storeTokenForSession(sessionId, tokenCache);
+  try {
+    await persistTokenForSession(sessionId, tokenCache);
+  } catch (error) {
+    if (isOAuthSessionStoreUnavailableError(error)) {
+      logger.error("OneDrive OAuth session store failed.", {
+        message: error.message,
+      });
+      return new Response(OAUTH_INFRASTRUCTURE_ERROR_MESSAGE, { status: 503 });
+    }
+    throw error;
+  }
 
   // stateクッキーをクリアしてリダイレクト
   const headers = new Headers();

--- a/app/routes/auth.onedrive.callback.tsx
+++ b/app/routes/auth.onedrive.callback.tsx
@@ -22,12 +22,21 @@ import {
 const OAUTH_FAILED_REDIRECT_PATH = "/?onedrive=oauth_failed";
 const OAUTH_INFRASTRUCTURE_ERROR_MESSAGE =
   "OneDrive 認証基盤で一時障害が発生しています。時間をおいて再試行してください。";
+const OAUTH_PERSIST_FAILED_AFTER_EXCHANGE_MESSAGE =
+  "OneDrive 認証情報の保存に失敗しました。Connect OneDrive から認証をやり直してください（authorization code は再利用できない可能性があります）。";
 
 async function buildOAuthFailureRedirect() {
   const headers = new Headers();
   headers.append("Set-Cookie", await onedriveOAuthStateCookie.serialize("", { maxAge: 0 }));
   headers.append("Set-Cookie", await onedriveOAuthBindCookie.serialize("", { maxAge: 0 }));
   return redirect(OAUTH_FAILED_REDIRECT_PATH, { headers });
+}
+
+async function buildOAuthInfrastructureErrorResponse(message: string) {
+  const headers = new Headers();
+  headers.append("Set-Cookie", await onedriveOAuthStateCookie.serialize("", { maxAge: 0 }));
+  headers.append("Set-Cookie", await onedriveOAuthBindCookie.serialize("", { maxAge: 0 }));
+  return new Response(message, { status: 503, headers });
 }
 
 // コールバックURLのローダー
@@ -128,7 +137,7 @@ export async function loader({ request }: { request: Request }) {
       logger.error("OneDrive OAuth session store failed.", {
         message: error.message,
       });
-      return new Response(OAUTH_INFRASTRUCTURE_ERROR_MESSAGE, { status: 503 });
+      return buildOAuthInfrastructureErrorResponse(OAUTH_PERSIST_FAILED_AFTER_EXCHANGE_MESSAGE);
     }
     throw error;
   }

--- a/app/routes/auth.onedrive.login.test.ts
+++ b/app/routes/auth.onedrive.login.test.ts
@@ -25,6 +25,7 @@ describe("auth.onedrive.login loader", () => {
   });
 
   it("Redis障害時は503で停止する", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const { ensureOAuthSessionStoreAvailable } = await import("../services/onedrive-oauth-session.server");
     vi.mocked(ensureOAuthSessionStoreAvailable).mockRejectedValue(
       new (class OAuthSessionStoreUnavailableError extends Error {
@@ -41,5 +42,7 @@ describe("auth.onedrive.login loader", () => {
 
     expect(response.status).toBe(503);
     expect(body).toContain("OneDrive 認証基盤で一時障害");
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/app/routes/auth.onedrive.login.test.ts
+++ b/app/routes/auth.onedrive.login.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { loader } from "./auth.onedrive.login";
+
+vi.mock("../services/onedrive-oauth-session.server", () => ({
+  OAuthSessionStoreUnavailableError: class OAuthSessionStoreUnavailableError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "OAuthSessionStoreUnavailableError";
+    }
+  },
+  ensureOAuthSessionStoreAvailable: vi.fn(async () => {}),
+  isOAuthSessionStoreUnavailableError: (error: unknown) =>
+    error instanceof Error && error.name === "OAuthSessionStoreUnavailableError",
+}));
 
 describe("auth.onedrive.login loader", () => {
   it("HTTPアクセスは400で拒否する", async () => {
@@ -10,5 +22,24 @@ describe("auth.onedrive.login loader", () => {
 
     expect(response.status).toBe(400);
     expect(body).toContain("Secure Cookie is unavailable on HTTP");
+  });
+
+  it("Redis障害時は503で停止する", async () => {
+    const { ensureOAuthSessionStoreAvailable } = await import("../services/onedrive-oauth-session.server");
+    vi.mocked(ensureOAuthSessionStoreAvailable).mockRejectedValue(
+      new (class OAuthSessionStoreUnavailableError extends Error {
+        constructor() {
+          super("redis down");
+          this.name = "OAuthSessionStoreUnavailableError";
+        }
+      })(),
+    );
+
+    const request = new Request("https://localhost:5173/auth/onedrive/login");
+    const response = await loader({ request });
+    const body = await response.text();
+
+    expect(response.status).toBe(503);
+    expect(body).toContain("OneDrive 認証基盤で一時障害");
   });
 });

--- a/app/routes/auth.onedrive.login.tsx
+++ b/app/routes/auth.onedrive.login.tsx
@@ -6,6 +6,7 @@ import { redirect } from "react-router";
 // HTTPSでのアクセスを要求する。
 // OneDrive OAuthはセキュアな環境でのみ動作するため、HTTPSでない場合はエラーレスポンスを返す。
 import { isHttpsRequest } from "../services/https-validation.server";
+import { logger } from "../services/logger.server";
 import { ensureOAuthSessionStoreAvailable, isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import {
   buildAuthorizeUrl,
@@ -27,6 +28,9 @@ export async function loader({ request }: { request: Request }) {
     await ensureOAuthSessionStoreAvailable();
   } catch (error) {
     if (isOAuthSessionStoreUnavailableError(error)) {
+      logger.error("OneDrive OAuth session store failed.", {
+        message: error.message,
+      });
       return new Response(
         "OneDrive 認証基盤で一時障害が発生しています。時間をおいて再試行してください。",
         { status: 503 },

--- a/app/routes/auth.onedrive.login.tsx
+++ b/app/routes/auth.onedrive.login.tsx
@@ -6,6 +6,7 @@ import { redirect } from "react-router";
 // HTTPSでのアクセスを要求する。
 // OneDrive OAuthはセキュアな環境でのみ動作するため、HTTPSでない場合はエラーレスポンスを返す。
 import { isHttpsRequest } from "../services/https-validation.server";
+import { ensureOAuthSessionStoreAvailable, isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import {
   buildAuthorizeUrl,
   onedriveOAuthBindCookie,
@@ -20,6 +21,18 @@ export async function loader({ request }: { request: Request }) {
       "HTTPS endpoint is required for OneDrive OAuth. Secure Cookie is unavailable on HTTP. Access via https://localhost:5173.",
       { status: 400 },
     );
+  }
+
+  try {
+    await ensureOAuthSessionStoreAvailable();
+  } catch (error) {
+    if (isOAuthSessionStoreUnavailableError(error)) {
+      return new Response(
+        "OneDrive 認証基盤で一時障害が発生しています。時間をおいて再試行してください。",
+        { status: 503 },
+      );
+    }
+    throw error;
   }
 
   // OAuth開始時のブラウザ文脈をcallbackで検証するため、bind IDをstateへ組み込む。

--- a/app/services/logger.server.ts
+++ b/app/services/logger.server.ts
@@ -1,0 +1,30 @@
+/* eslint-disable no-console */
+/**
+ * サーバー向けロガー
+ *
+ * このファイルを用意した理由:
+ * - server route/service から `console` 直接呼び出しをなくし、ログ出力の入口を1か所に寄せるため。
+ * - 将来の構造化ログや外部転送へ差し替えやすくするため。
+ *
+ * このファイルが使われる場面:
+ * - OAuth/Redis/OneDrive 障害や rollback 失敗などをサーバーログへ残すとき。
+ */
+
+type LogPayload = Record<string, unknown> | undefined;
+
+function write(method: "warn" | "error", message: string, payload?: LogPayload) {
+  if (payload) {
+    console[method](message, payload);
+    return;
+  }
+  console[method](message);
+}
+
+export const logger = {
+  warn(message: string, payload?: LogPayload) {
+    write("warn", message, payload);
+  },
+  error(message: string, payload?: LogPayload) {
+    write("error", message, payload);
+  },
+};

--- a/app/services/onedrive-auth.server.test.ts
+++ b/app/services/onedrive-auth.server.test.ts
@@ -1,8 +1,62 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+const { mockSessionStore } = vi.hoisted(() => ({
+  mockSessionStore: new Map<string, { accessToken: string; refreshToken: string | null; expiresAt: number }>(),
+}));
+const { mockRefreshLocks } = vi.hoisted(() => ({
+  mockRefreshLocks: new Set<string>(),
+}));
+const { mockRefreshFailures } = vi.hoisted(() => ({
+  mockRefreshFailures: new Map<string, string>(),
+}));
+const { mockTryAcquireRefreshLock } = vi.hoisted(() => ({
+  mockTryAcquireRefreshLock: vi.fn(async (sessionId: string, _ttlMs: number) => {
+    if (mockRefreshLocks.has(sessionId)) return false;
+    mockRefreshLocks.add(sessionId);
+    return `lock-${sessionId}`;
+  }),
+}));
+
+vi.mock("./onedrive-oauth-session.server", () => ({
+  OAuthSessionStoreUnavailableError: class OAuthSessionStoreUnavailableError extends Error {},
+  isOAuthSessionStoreUnavailableError: (error: unknown) => error instanceof Error && error.name === "OAuthSessionStoreUnavailableError",
+  ensureOAuthSessionStoreAvailable: vi.fn(async () => {}),
+  storeTokenForSession: vi.fn(async (sessionId: string, cache: { accessToken: string; refreshToken: string | null; expiresAt: number }) => {
+    mockSessionStore.set(sessionId, cache);
+  }),
+  getTokenForSession: vi.fn(async (sessionId: string | null) => (sessionId ? mockSessionStore.get(sessionId) ?? null : null)),
+  deleteTokenForSession: vi.fn(async (sessionId: string) => {
+    mockSessionStore.delete(sessionId);
+  }),
+  clearRefreshFailure: vi.fn(async (sessionId: string) => {
+    mockRefreshFailures.delete(sessionId);
+  }),
+  storeRefreshFailure: vi.fn(async (sessionId: string, message: string) => {
+    mockRefreshFailures.set(sessionId, message);
+  }),
+  tryAcquireRefreshLock: mockTryAcquireRefreshLock,
+  releaseRefreshLock: vi.fn(async (sessionId: string) => {
+    mockRefreshLocks.delete(sessionId);
+  }),
+  waitForRefreshOutcome: vi.fn(async (sessionId: string) => {
+    for (let attempt = 0; attempt < 30; attempt++) {
+      const token = mockSessionStore.get(sessionId) ?? null;
+      if (token?.accessToken.startsWith("new-access-token")) {
+        return { kind: "token", token };
+      }
+      const failure = mockRefreshFailures.get(sessionId);
+      if (failure) {
+        return { kind: "error", message: failure };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    return null;
+  }),
+}));
+
 import {
   getAccessToken,
   onedriveOAuthSessionCookie,
-  storeTokenForSession,
+  persistTokenForSession,
 } from "./onedrive-auth.server";
 
 describe("onedrive-auth refresh single-flight", () => {
@@ -10,16 +64,22 @@ describe("onedrive-auth refresh single-flight", () => {
     process.env.ONEDRIVE_CLIENT_ID = "test-client";
     process.env.ONEDRIVE_CLIENT_SECRET = "test-secret";
     process.env.ONEDRIVE_REDIRECT_URI = "https://localhost:5173/auth/onedrive/callback";
+    process.env.REDIS_URL = "redis://localhost:6379/0";
   });
 
   afterEach(() => {
+    mockSessionStore.clear();
+    mockRefreshLocks.clear();
+    mockRefreshFailures.clear();
+    mockTryAcquireRefreshLock.mockClear();
+    delete process.env.REDIS_URL;
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
   it("同一セッションの同時リフレッシュを1回に集約する", async () => {
     const sessionId = `session-${crypto.randomUUID()}`;
-    storeTokenForSession(sessionId, {
+    await persistTokenForSession(sessionId, {
       accessToken: "expired-access",
       refreshToken: "refresh-token-1",
       expiresAt: Date.now() - 1000,
@@ -49,6 +109,7 @@ describe("onedrive-auth refresh single-flight", () => {
     expect(token1).toBe("new-access-token");
     expect(token2).toBe("new-access-token");
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mockTryAcquireRefreshLock).toHaveBeenCalledWith(sessionId, 185000);
 
     const token3 = await getAccessToken(request);
     expect(token3).toBe("new-access-token");
@@ -57,7 +118,7 @@ describe("onedrive-auth refresh single-flight", () => {
 
   it("refresh タイムアウト後は single-flight ロックを解放して再試行できる", async () => {
     const sessionId = `session-${crypto.randomUUID()}`;
-    storeTokenForSession(sessionId, {
+    await persistTokenForSession(sessionId, {
       accessToken: "expired-access",
       refreshToken: "refresh-token-1",
       expiresAt: Date.now() - 1000,
@@ -91,5 +152,33 @@ describe("onedrive-auth refresh single-flight", () => {
 
     expect(token).toBe("new-access-token-after-timeout");
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("先行refresh失敗時は後続も同じ失敗理由を受け取る", async () => {
+    const sessionId = `session-${crypto.randomUUID()}`;
+    await persistTokenForSession(sessionId, {
+      accessToken: "expired-access",
+      refreshToken: "refresh-token-1",
+      expiresAt: Date.now() - 1000,
+    });
+    vi.spyOn(onedriveOAuthSessionCookie, "parse").mockResolvedValue(sessionId as never);
+    const request = {
+      headers: { get: (name: string) => (name.toLowerCase() === "cookie" ? "onedrive_oauth_session=stub" : null) },
+    } as Request;
+
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce((_input: RequestInfo | URL, init?: RequestInit) => {
+        expect(init?.signal).toBeDefined();
+        return Promise.reject(new DOMException("timed out", "TimeoutError"));
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tokenPromise1 = getAccessToken(request);
+    const tokenPromise2 = getAccessToken(request);
+
+    await expect(tokenPromise1).rejects.toThrow(/timed out after \d+ms/);
+    await expect(tokenPromise2).rejects.toThrow(/timed out after \d+ms/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/services/onedrive-auth.server.test.ts
+++ b/app/services/onedrive-auth.server.test.ts
@@ -15,6 +15,11 @@ const { mockTryAcquireRefreshLock } = vi.hoisted(() => ({
     return `lock-${sessionId}`;
   }),
 }));
+const { mockReleaseRefreshLock } = vi.hoisted(() => ({
+  mockReleaseRefreshLock: vi.fn(async (sessionId: string) => {
+    mockRefreshLocks.delete(sessionId);
+  }),
+}));
 
 vi.mock("./onedrive-oauth-session.server", () => ({
   OAuthSessionStoreUnavailableError: class OAuthSessionStoreUnavailableError extends Error {},
@@ -34,9 +39,7 @@ vi.mock("./onedrive-oauth-session.server", () => ({
     mockRefreshFailures.set(sessionId, message);
   }),
   tryAcquireRefreshLock: mockTryAcquireRefreshLock,
-  releaseRefreshLock: vi.fn(async (sessionId: string) => {
-    mockRefreshLocks.delete(sessionId);
-  }),
+  releaseRefreshLock: mockReleaseRefreshLock,
   waitForRefreshOutcome: vi.fn(async (sessionId: string) => {
     for (let attempt = 0; attempt < 30; attempt++) {
       const token = mockSessionStore.get(sessionId) ?? null;
@@ -72,6 +75,7 @@ describe("onedrive-auth refresh single-flight", () => {
     mockRefreshLocks.clear();
     mockRefreshFailures.clear();
     mockTryAcquireRefreshLock.mockClear();
+    mockReleaseRefreshLock.mockClear();
     delete process.env.REDIS_URL;
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -180,5 +184,36 @@ describe("onedrive-auth refresh single-flight", () => {
     await expect(tokenPromise1).rejects.toThrow(/timed out after \d+ms/);
     await expect(tokenPromise2).rejects.toThrow(/timed out after \d+ms/);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("unlock が失敗しても refresh 成功結果を返す", async () => {
+    const sessionId = `session-${crypto.randomUUID()}`;
+    await persistTokenForSession(sessionId, {
+      accessToken: "expired-access",
+      refreshToken: "refresh-token-1",
+      expiresAt: Date.now() - 1000,
+    });
+    vi.spyOn(onedriveOAuthSessionCookie, "parse").mockResolvedValue(sessionId as never);
+    const request = {
+      headers: { get: (name: string) => (name.toLowerCase() === "cookie" ? "onedrive_oauth_session=stub" : null) },
+    } as Request;
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "new-access-token-after-unlock-failure",
+          refresh_token: "refresh-token-2",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    mockReleaseRefreshLock.mockRejectedValueOnce(new Error("redis timeout on unlock"));
+
+    await expect(getAccessToken(request)).resolves.toBe("new-access-token-after-unlock-failure");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mockSessionStore.get(sessionId)?.accessToken).toBe("new-access-token-after-unlock-failure");
   });
 });

--- a/app/services/onedrive-auth.server.test.ts
+++ b/app/services/onedrive-auth.server.test.ts
@@ -20,6 +20,11 @@ const { mockReleaseRefreshLock } = vi.hoisted(() => ({
     mockRefreshLocks.delete(sessionId);
   }),
 }));
+const { mockStoreRefreshFailure } = vi.hoisted(() => ({
+  mockStoreRefreshFailure: vi.fn(async (sessionId: string, message: string) => {
+    mockRefreshFailures.set(sessionId, message);
+  }),
+}));
 
 vi.mock("./onedrive-oauth-session.server", () => ({
   OAuthSessionStoreUnavailableError: class OAuthSessionStoreUnavailableError extends Error {},
@@ -35,9 +40,7 @@ vi.mock("./onedrive-oauth-session.server", () => ({
   clearRefreshFailure: vi.fn(async (sessionId: string) => {
     mockRefreshFailures.delete(sessionId);
   }),
-  storeRefreshFailure: vi.fn(async (sessionId: string, message: string) => {
-    mockRefreshFailures.set(sessionId, message);
-  }),
+  storeRefreshFailure: mockStoreRefreshFailure,
   tryAcquireRefreshLock: mockTryAcquireRefreshLock,
   releaseRefreshLock: mockReleaseRefreshLock,
   waitForRefreshOutcome: vi.fn(async (sessionId: string) => {
@@ -76,6 +79,7 @@ describe("onedrive-auth refresh single-flight", () => {
     mockRefreshFailures.clear();
     mockTryAcquireRefreshLock.mockClear();
     mockReleaseRefreshLock.mockClear();
+    mockStoreRefreshFailure.mockClear();
     delete process.env.REDIS_URL;
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -215,5 +219,28 @@ describe("onedrive-auth refresh single-flight", () => {
     await expect(getAccessToken(request)).resolves.toBe("new-access-token-after-unlock-failure");
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(mockSessionStore.get(sessionId)?.accessToken).toBe("new-access-token-after-unlock-failure");
+  });
+
+  it("refreshFailure 保存が失敗しても元の refresh エラーを返す", async () => {
+    const sessionId = `session-${crypto.randomUUID()}`;
+    await persistTokenForSession(sessionId, {
+      accessToken: "expired-access",
+      refreshToken: "refresh-token-1",
+      expiresAt: Date.now() - 1000,
+    });
+    vi.spyOn(onedriveOAuthSessionCookie, "parse").mockResolvedValue(sessionId as never);
+    const request = {
+      headers: { get: (name: string) => (name.toLowerCase() === "cookie" ? "onedrive_oauth_session=stub" : null) },
+    } as Request;
+
+    const fetchMock = vi.fn().mockImplementationOnce((_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.signal).toBeDefined();
+      return Promise.reject(new DOMException("timed out", "TimeoutError"));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    mockStoreRefreshFailure.mockRejectedValueOnce(new Error("redis write timed out"));
+
+    await expect(getAccessToken(request)).rejects.toThrow(/timed out after \d+ms/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/services/onedrive-auth.server.test.ts
+++ b/app/services/onedrive-auth.server.test.ts
@@ -25,6 +25,22 @@ const { mockStoreRefreshFailure } = vi.hoisted(() => ({
     mockRefreshFailures.set(sessionId, message);
   }),
 }));
+const { mockWaitForRefreshOutcome } = vi.hoisted(() => ({
+  mockWaitForRefreshOutcome: vi.fn(async (sessionId: string) => {
+    for (let attempt = 0; attempt < 30; attempt++) {
+      const token = mockSessionStore.get(sessionId) ?? null;
+      if (token?.accessToken.startsWith("new-access-token")) {
+        return { kind: "token", token };
+      }
+      const failure = mockRefreshFailures.get(sessionId);
+      if (failure) {
+        return { kind: "error", message: failure };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    return null;
+  }),
+}));
 
 vi.mock("./onedrive-oauth-session.server", () => ({
   OAuthSessionStoreUnavailableError: class OAuthSessionStoreUnavailableError extends Error {},
@@ -43,20 +59,7 @@ vi.mock("./onedrive-oauth-session.server", () => ({
   storeRefreshFailure: mockStoreRefreshFailure,
   tryAcquireRefreshLock: mockTryAcquireRefreshLock,
   releaseRefreshLock: mockReleaseRefreshLock,
-  waitForRefreshOutcome: vi.fn(async (sessionId: string) => {
-    for (let attempt = 0; attempt < 30; attempt++) {
-      const token = mockSessionStore.get(sessionId) ?? null;
-      if (token?.accessToken.startsWith("new-access-token")) {
-        return { kind: "token", token };
-      }
-      const failure = mockRefreshFailures.get(sessionId);
-      if (failure) {
-        return { kind: "error", message: failure };
-      }
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
-    return null;
-  }),
+  waitForRefreshOutcome: mockWaitForRefreshOutcome,
 }));
 
 import {
@@ -80,6 +83,7 @@ describe("onedrive-auth refresh single-flight", () => {
     mockTryAcquireRefreshLock.mockClear();
     mockReleaseRefreshLock.mockClear();
     mockStoreRefreshFailure.mockClear();
+    mockWaitForRefreshOutcome.mockClear();
     delete process.env.REDIS_URL;
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -118,6 +122,7 @@ describe("onedrive-auth refresh single-flight", () => {
     expect(token2).toBe("new-access-token");
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(mockTryAcquireRefreshLock).toHaveBeenCalledWith(sessionId, 185000);
+    expect(mockWaitForRefreshOutcome).toHaveBeenCalledWith(sessionId, 60000);
 
     const token3 = await getAccessToken(request);
     expect(token3).toBe("new-access-token");

--- a/app/services/onedrive-auth.server.test.ts
+++ b/app/services/onedrive-auth.server.test.ts
@@ -122,7 +122,7 @@ describe("onedrive-auth refresh single-flight", () => {
     expect(token2).toBe("new-access-token");
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(mockTryAcquireRefreshLock).toHaveBeenCalledWith(sessionId, 185000);
-    expect(mockWaitForRefreshOutcome).toHaveBeenCalledWith(sessionId, 60000);
+    expect(mockWaitForRefreshOutcome).toHaveBeenCalledWith(sessionId, 187000);
 
     const token3 = await getAccessToken(request);
     expect(token3).toBe("new-access-token");

--- a/app/services/onedrive-auth.server.ts
+++ b/app/services/onedrive-auth.server.ts
@@ -26,6 +26,7 @@ const AUTH_BASE_URL = "https://login.microsoftonline.com";
 const DEFAULT_TENANT = "common";
 const SCOPES = ["offline_access", "Files.ReadWrite", "User.Read"];
 const DEFAULT_OAUTH_REQUEST_TIMEOUT_SECONDS = 180;
+const DEFAULT_REFRESH_WAIT_TIMEOUT_SECONDS = 60;
 const REFRESH_LOCK_TTL_BUFFER_MS = 5000;
 
 function parseTimeoutSecondsToMs(value: string | undefined, fallbackMs: number): number {
@@ -39,7 +40,10 @@ const OAUTH_REQUEST_TIMEOUT_MS = parseTimeoutSecondsToMs(
   DEFAULT_OAUTH_REQUEST_TIMEOUT_SECONDS * 1000,
 );
 const REFRESH_LOCK_TTL_MS = OAUTH_REQUEST_TIMEOUT_MS + REFRESH_LOCK_TTL_BUFFER_MS;
-const REFRESH_WAIT_MS = REFRESH_LOCK_TTL_MS;
+const REFRESH_WAIT_MS = parseTimeoutSecondsToMs(
+  process.env.ONEDRIVE_REFRESH_WAIT_TIMEOUT_SECONDS,
+  DEFAULT_REFRESH_WAIT_TIMEOUT_SECONDS * 1000,
+);
 const REFRESH_FAILURE_TTL_SECONDS = Math.ceil(REFRESH_WAIT_MS / 1000);
 
 // Microsoft Entra ID の token endpoint が返すレスポンスのうち、本実装で使う項目だけを表す。

--- a/app/services/onedrive-auth.server.ts
+++ b/app/services/onedrive-auth.server.ts
@@ -19,6 +19,7 @@ import {
   waitForRefreshOutcome,
 } from "./onedrive-oauth-session.server";
 import type { TokenCache } from "./onedrive-oauth-session.server";
+import { logger } from "./logger.server";
 import { resolvedSessionSecret } from "./session-secret.server";
 
 const AUTH_BASE_URL = "https://login.microsoftonline.com";
@@ -235,7 +236,15 @@ async function refreshAccessTokenForSession(sessionId: string, refreshToken: str
       }
       throw error;
     } finally {
-      await releaseRefreshLock(sessionId, lockToken);
+      try {
+        await releaseRefreshLock(sessionId, lockToken);
+      } catch (error) {
+        // unlock 失敗は可用性優先でベストエフォート化し、成功済み refresh 結果は維持する。
+        logger.warn("Failed to release OneDrive refresh lock.", {
+          sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   }
 

--- a/app/services/onedrive-auth.server.ts
+++ b/app/services/onedrive-auth.server.ts
@@ -1,24 +1,31 @@
 /**
-  * OneDrive OAuthサービス（サーバー側）
-  * 現時点の前提:
-  * - 認証フロー（OAuth/MSAL）を実装する
-  * - トークンはメモリキャッシュで管理（開発用）。本番環境ではDB等に保存する想定
-  * - リフレッシュトークン対応
-**/
-
-// これらの関数は、OneDrive OAuthフローの実装に必要なユーティリティ関数やサービスを提供する。
-// 例えば、OAuthの認可URLを生成する関数や、トークンを交換する関数などが含まれる。
-// これらの関数は、認証ルートのローダーやアクションで利用される。
+ * OneDrive OAuthサービス（サーバー側）
+ *
+ * 前提:
+ * - 認証フローを実装する
+ * - OAuthトークンは Redis ベースのサーバー側セッションストアで管理する
+ * - リフレッシュトークン対応
+ */
 import { createCookie } from "react-router";
-import { isProduction, resolvedSessionSecret } from "./session-secret.server";
+// 注意: これらの関数はサーバー側でのみ呼び出すこと。クライアント側で呼び出すとエラーになる。
+import {
+  clearRefreshFailure,
+  getTokenForSession,
+  OAuthSessionStoreUnavailableError,
+  releaseRefreshLock,
+  storeTokenForSession,
+  storeRefreshFailure,
+  tryAcquireRefreshLock,
+  waitForRefreshOutcome,
+} from "./onedrive-oauth-session.server";
+import type { TokenCache } from "./onedrive-oauth-session.server";
+import { resolvedSessionSecret } from "./session-secret.server";
 
-// Microsoft Entra ID (旧AAD) OAuth2エンドポイント
 const AUTH_BASE_URL = "https://login.microsoftonline.com";
-// デフォルトテナント（common: 個人/組織アカウント両対応）
 const DEFAULT_TENANT = "common";
-// OAuthスコープ
 const SCOPES = ["offline_access", "Files.ReadWrite", "User.Read"];
 const DEFAULT_OAUTH_REQUEST_TIMEOUT_SECONDS = 180;
+const REFRESH_LOCK_TTL_BUFFER_MS = 5000;
 
 function parseTimeoutSecondsToMs(value: string | undefined, fallbackMs: number): number {
   const parsedSeconds = Number.parseInt(value ?? "", 10);
@@ -30,8 +37,11 @@ const OAUTH_REQUEST_TIMEOUT_MS = parseTimeoutSecondsToMs(
   process.env.ONEDRIVE_OAUTH_REQUEST_TIMEOUT_SECONDS,
   DEFAULT_OAUTH_REQUEST_TIMEOUT_SECONDS * 1000,
 );
+const REFRESH_LOCK_TTL_MS = OAUTH_REQUEST_TIMEOUT_MS + REFRESH_LOCK_TTL_BUFFER_MS;
+const REFRESH_WAIT_MS = REFRESH_LOCK_TTL_MS;
+const REFRESH_FAILURE_TTL_SECONDS = Math.ceil(REFRESH_WAIT_MS / 1000);
 
-// OAuthトークンレスポンス
+// Microsoft Entra ID の token endpoint が返すレスポンスのうち、本実装で使う項目だけを表す。
 type TokenResponse = {
   access_token: string;
   refresh_token?: string;
@@ -40,119 +50,29 @@ type TokenResponse = {
   scope?: string;
 };
 
-// トークンキャッシュ構造体
-type TokenCache = {
-  accessToken: string;
-  refreshToken: string | null;
-  expiresAt: number;
-};
-
-// セッションID => トークンキャッシュ（開発用）
-// Cookieにはトークン本体を入れず、セッションIDだけを保存して参照する。
-// Eviction 方針:
-// - Map の挿入順を利用した簡易 LRU。
-// - 参照(get)・更新(store)時に delete/set で末尾へ移動し、先頭を最も古い要素として扱う。
-const tokenStore = new Map<string, TokenCache>();
-// 同一セッションでの同時refreshを1回に集約する。
-const refreshInFlightBySession = new Map<string, Promise<TokenCache>>();
-// トークンストアの最大セッション数（開発用）
-const DEFAULT_TOKEN_STORE_MAX_SESSIONS = 500;
-const allowInMemoryTokenStoreInProduction =
-  (process.env.ONEDRIVE_ALLOW_IN_MEMORY_TOKEN_STORE_IN_PRODUCTION ?? "").toLowerCase() === "true" ||
-  process.env.ONEDRIVE_ALLOW_IN_MEMORY_TOKEN_STORE_IN_PRODUCTION === "1";
-let warnedInMemoryTokenStoreInProduction = false;
-// OAuth設定が完了しているか確認する
 function isOneDriveOAuthConfigured(): boolean {
   return Boolean(process.env.ONEDRIVE_CLIENT_ID && process.env.ONEDRIVE_CLIENT_SECRET && process.env.ONEDRIVE_REDIRECT_URI);
 }
-// 本番環境でメモリ内トークンストアの使用が許可されているか確認する
-function ensureInMemoryTokenStoreAllowedForCurrentEnv() {
-  if (!isProduction) return;
-  // OneDrive OAuth を使わないデプロイでは、起動不能にしない。
+
+// OAuth 設定が揃っている経路では Redis も必須にし、fail-closed の前提を崩さない。
+function ensureOAuthStoreConfigured() {
   if (!isOneDriveOAuthConfigured()) return;
-  if (!allowInMemoryTokenStoreInProduction) {
-    throw new Error(
-      "本番環境でメモリ内 tokenStore は使用できません。Redis/DB などの永続ストアを実装するか、" +
-        "一時的に ONEDRIVE_ALLOW_IN_MEMORY_TOKEN_STORE_IN_PRODUCTION=true を設定してください。",
-    );
-  }
-  if (!warnedInMemoryTokenStoreInProduction) {
-    warnedInMemoryTokenStoreInProduction = true;
-    console.warn(
-      "本番環境でメモリ内 tokenStore を許可しています。プロセス再起動・スケールアウト時に OAuth セッションは失われます。",
+  if (!process.env.REDIS_URL?.trim()) {
+    throw new OAuthSessionStoreUnavailableError(
+      "Redis session store is not configured. Set REDIS_URL before using OneDrive OAuth.",
     );
   }
 }
 
-// トークンストアの最大セッション数を環境変数から取得する
-// 返り値: 正の整数（未設定/不正値の場合はデフォルト値を返す）
-function getTokenStoreMaxSessions(): number {
-  const raw = process.env.ONEDRIVE_TOKEN_STORE_MAX_SESSIONS; // 任意
-  const parsed = Number.parseInt(raw ?? "", 10); // NaNの場合もある
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TOKEN_STORE_MAX_SESSIONS; // デフォルト値
-  return parsed;
-}
-
-// 期限切れかつリフレッシュ不能なセッションのみ削除する
-function purgeExpiredUnrefreshableTokenSessions(now = Date.now()) {
-  // tokenStore を全走査して、期限切れかつリフレッシュトークンがないセッションを削除する。
-  for (const [key, value] of tokenStore.entries()) {
-    // 期限切れかつリフレッシュトークンがないセッションを削除
-    if (value.expiresAt <= now && !value.refreshToken) {
-      tokenStore.delete(key);
-    }
-  }
-}
-
-// トークンストアのセッション数が上限を超えていたら古いものから削除する
-function enforceTokenStoreLimit() {
-  // 上限セッション数を取得
-  const limit = getTokenStoreMaxSessions();
-  // 上限を超えていたら古いものから削除
-  while (tokenStore.size > limit) {
-    // 可能なら refresh 不可セッションを優先的に削除して、再利用可能なセッションを温存する。
-    let candidateKey: string | undefined;
-    // tokenStore は Map なので、entries() の順序は挿入順（LRU順）になっている。
-    // 先頭から走査して、最初に見つかった refreshToken がないセッションを削除候補とする。
-    let evictionReason: "non_refreshable_first" | "oldest_fallback" = "oldest_fallback";
-    for (const [key, value] of tokenStore.entries()) {
-      if (!candidateKey) candidateKey = key;
-      if (!value.refreshToken) {
-        candidateKey = key;
-        evictionReason = "non_refreshable_first";
-        break;
-      }
-    }
-    if (!candidateKey) break;
-    tokenStore.delete(candidateKey);
-    console.warn("OneDrive tokenStore evicted a session due to size limit.", {
-      limit,
-      sizeAfterEviction: tokenStore.size,
-      evictionReason,
-    });
-  }
-}
-// トークンストアの管理関数
-function maintainTokenStore(now = Date.now()) {
-  ensureInMemoryTokenStoreAllowedForCurrentEnv();
-  // 期限切れかつリフレッシュ不能なセッションを削除する。
-  // これにより、無効なセッションが残らないようになる。
-  purgeExpiredUnrefreshableTokenSessions(now);
-  // セッション数が上限を超えていたら古いものから削除する。
-  enforceTokenStoreLimit();
-}
-
-// OAuth状態管理用Cookie
 export const onedriveOAuthStateCookie = createCookie("onedrive_oauth_state", {
-  httpOnly: true, // cookieをJavaScriptから参照できないようにする
+  httpOnly: true,
   path: "/",
   sameSite: "lax",
   maxAge: 60 * 5,
-  secure: true, // HTTPS限定
+  secure: true,
   secrets: [resolvedSessionSecret],
 });
 
-// OAuth開始時とcallback時のブラウザ整合性を確認する短期バインドCookie
 export const onedriveOAuthBindCookie = createCookie("onedrive_oauth_bind", {
   httpOnly: true,
   path: "/",
@@ -162,18 +82,15 @@ export const onedriveOAuthBindCookie = createCookie("onedrive_oauth_bind", {
   secrets: [resolvedSessionSecret],
 });
 
-// OAuthセッションID保持用Cookie
-// 値は tokenStore のキーとして利用する。
 export const onedriveOAuthSessionCookie = createCookie("onedrive_oauth_session", {
-  httpOnly: true, // cookieをJavaScriptから参照できないようにする
+  httpOnly: true,
   path: "/",
   sameSite: "lax",
   maxAge: 60 * 60 * 24 * 7,
-  secure: true, // HTTPS限定
+  secure: true,
   secrets: [resolvedSessionSecret],
 });
 
-// 環境変数からOAuth設定を取得する
 function getTenant(): string {
   return process.env.ONEDRIVE_TENANT ?? DEFAULT_TENANT;
 }
@@ -190,7 +107,6 @@ function getRedirectUri(): string {
   return process.env.ONEDRIVE_REDIRECT_URI ?? "";
 }
 
-// OAuth設定が完了しているか確認する
 function ensureConfig() {
   const clientId = getClientId();
   const clientSecret = getClientSecret();
@@ -200,19 +116,17 @@ function ensureConfig() {
       "OneDrive OAuth設定が未完了です。ONEDRIVE_CLIENT_ID / ONEDRIVE_CLIENT_SECRET / ONEDRIVE_REDIRECT_URI を設定してください",
     );
   }
+  ensureOAuthStoreConfigured();
 }
 
-// OAuthエンドポイント取得する
 function getAuthorizeEndpoint(): string {
   return `${AUTH_BASE_URL}/${encodeURIComponent(getTenant())}/oauth2/v2.0/authorize`;
 }
 
-// トークンエンドポイント取得する
 function getTokenEndpoint(): string {
   return `${AUTH_BASE_URL}/${encodeURIComponent(getTenant())}/oauth2/v2.0/token`;
 }
 
-// 認可URLを構築する
 export function buildAuthorizeUrl(state: string): string {
   ensureConfig();
   const params = new URLSearchParams({
@@ -222,12 +136,12 @@ export function buildAuthorizeUrl(state: string): string {
     response_mode: "query",
     scope: SCOPES.join(" "),
     state,
-    // SSOで即時リダイレクトされるケースでも、明示的に認証画面を表示する
     prompt: "select_account",
   });
   return `${getAuthorizeEndpoint()}?${params.toString()}`;
 }
 
+// OAuth の `expires_in` をそのまま使わず、少し早めに失効扱いへ寄せて refresh の余裕を残す。
 function toTokenCache(response: TokenResponse, previousRefreshToken: string | null = null): TokenCache {
   const expiresAt = Date.now() + Math.max(response.expires_in - 60, 30) * 1000;
   return {
@@ -236,45 +150,18 @@ function toTokenCache(response: TokenResponse, previousRefreshToken: string | nu
     expiresAt,
   };
 }
-// 非同期でセッションIDをCookieから取得する
+
+// Cookie 改ざんや欠落は認証切れ扱いに寄せたいため、parse 失敗時は null に丸める。
 async function getSessionId(cookieHeader: string | null): Promise<string | null> {
-  // Cookieヘッダーがない場合はnullを返す
   if (!cookieHeader) return null;
   try {
-    // onedriveOAuthSessionCookieを使ってセッションIDを安全に取得する
     const raw = (await onedriveOAuthSessionCookie.parse(cookieHeader)) as string | null;
     return raw ?? null;
   } catch {
-    // 解析に失敗した場合はnullを返す
     return null;
   }
 }
 
-export function storeTokenForSession(sessionId: string, cache: TokenCache) {
-  // OAuth callback 直後に、セッションIDへ取得トークンを紐づける。
-  maintainTokenStore();
-  // 既存キーを再挿入してMap末尾へ移動し、LRU順序を維持する。
-  tokenStore.delete(sessionId);
-  // セッションIDにトークンキャッシュを保存する。
-  tokenStore.set(sessionId, cache);
-  // 追加後のサイズ超過を解消する。
-  maintainTokenStore();
-}
-
-function getTokenForSession(sessionId: string | null): TokenCache | null {
-  if (!sessionId) return null;
-  // セッションIDに紐づくトークンキャッシュを取得する。
-  // これにより、APIリクエストなどでセッションに対応するトークンを利用できるようになる。
-  maintainTokenStore();
-  const cache = tokenStore.get(sessionId);
-  if (!cache) return null;
-  // 参照したセッションを末尾へ移動し、最近利用順を更新する。
-  tokenStore.delete(sessionId);
-  tokenStore.set(sessionId, cache);
-  return cache;
-}
-
-// トークンをリクエストする
 async function requestToken(params: URLSearchParams): Promise<TokenResponse> {
   let response: Response;
   try {
@@ -291,7 +178,6 @@ async function requestToken(params: URLSearchParams): Promise<TokenResponse> {
     throw error;
   }
 
-  // エラーハンドリング
   if (!response.ok) {
     const text = await response.text();
     throw new Error(`OneDrive OAuth error (${response.status}): ${text}`);
@@ -300,7 +186,6 @@ async function requestToken(params: URLSearchParams): Promise<TokenResponse> {
   return (await response.json()) as TokenResponse;
 }
 
-// OneDrive Graph API関連ユーティリティ
 export async function exchangeCodeForToken(code: string): Promise<TokenCache> {
   ensureConfig();
   const params = new URLSearchParams({
@@ -315,7 +200,6 @@ export async function exchangeCodeForToken(code: string): Promise<TokenCache> {
   return toTokenCache(token);
 }
 
-// リフレッシュトークンでアクセストークンを更新する。
 async function refreshAccessToken(refreshToken: string): Promise<TokenCache> {
   ensureConfig();
   const params = new URLSearchParams({
@@ -328,40 +212,57 @@ async function refreshAccessToken(refreshToken: string): Promise<TokenCache> {
   const token = await requestToken(params);
   return toTokenCache(token, refreshToken);
 }
-// セッションIDとリフレッシュトークンを使ってアクセストークンを更新する。複数リクエストの同時更新を防止する。
-async function refreshAccessTokenForSession(sessionId: string, refreshToken: string): Promise<TokenCache> {
-  const inFlight = refreshInFlightBySession.get(sessionId);
-  if (inFlight) return inFlight;
 
-  const refreshPromise = (async () => {
-    const refreshed = await refreshAccessToken(refreshToken);
-    storeTokenForSession(sessionId, refreshed);
-    return refreshed;
-  })().finally(() => {
-    refreshInFlightBySession.delete(sessionId);
-  });
-
-  refreshInFlightBySession.set(sessionId, refreshPromise);
-  return refreshPromise;
+// Redis ストアを経由した token 永続化の入口を 1 箇所に寄せる。
+export async function persistTokenForSession(sessionId: string, cache: TokenCache): Promise<void> {
+  ensureOAuthStoreConfigured();
+  await storeTokenForSession(sessionId, cache);
 }
 
-// 有効なアクセストークンを取得する
+// 複数インスタンスでの refresh 競合を Redis ロックで直列化し、失敗時もロックを確実に解放する。
+async function refreshAccessTokenForSession(sessionId: string, refreshToken: string): Promise<TokenCache> {
+  const lockToken = await tryAcquireRefreshLock(sessionId, REFRESH_LOCK_TTL_MS);
+  if (lockToken) {
+    try {
+      await clearRefreshFailure(sessionId);
+      const refreshed = await refreshAccessToken(refreshToken);
+      await persistTokenForSession(sessionId, refreshed);
+      return refreshed;
+    } catch (error) {
+      if (!(error instanceof OAuthSessionStoreUnavailableError)) {
+        const message = error instanceof Error ? error.message : String(error);
+        await storeRefreshFailure(sessionId, message, REFRESH_FAILURE_TTL_SECONDS);
+      }
+      throw error;
+    } finally {
+      await releaseRefreshLock(sessionId, lockToken);
+    }
+  }
+
+  const outcome = await waitForRefreshOutcome(sessionId, REFRESH_WAIT_MS);
+  if (outcome?.kind === "token") return outcome.token;
+  if (outcome?.kind === "error") {
+    throw new Error(outcome.message);
+  }
+
+  throw new OAuthSessionStoreUnavailableError(
+    "Timed out while waiting for another worker to finish refreshing the OneDrive OAuth token.",
+  );
+}
+
 export async function getAccessToken(request?: Request): Promise<string> {
-  // API経由の取得は、必ずCookieのセッションと紐づくトークンのみを使う。
-  // 別セッションのグローバルトークンを使うと401の原因になる。
   if (request) {
+    // request 経路では、そのブラウザの sessionId に紐づく token だけを使う。
+    ensureOAuthStoreConfigured();
     const sessionId = await getSessionId(request.headers.get("Cookie"));
-    const sessionToken = getTokenForSession(sessionId);
+    const sessionToken = await getTokenForSession(sessionId);
 
     if (sessionToken && sessionToken.expiresAt > Date.now()) {
       return sessionToken.accessToken;
     }
 
-    if (sessionToken?.refreshToken) {
-      // セッションのリフレッシュトークンで更新を試みる。成功すればセッションを継続できる。
-      const refreshed = sessionId
-        ? await refreshAccessTokenForSession(sessionId, sessionToken.refreshToken)
-        : await refreshAccessToken(sessionToken.refreshToken);
+    if (sessionId && sessionToken?.refreshToken) {
+      const refreshed = await refreshAccessTokenForSession(sessionId, sessionToken.refreshToken);
       return refreshed.accessToken;
     }
 

--- a/app/services/onedrive-auth.server.ts
+++ b/app/services/onedrive-auth.server.ts
@@ -28,6 +28,7 @@ const SCOPES = ["offline_access", "Files.ReadWrite", "User.Read"];
 const DEFAULT_OAUTH_REQUEST_TIMEOUT_SECONDS = 180;
 const DEFAULT_REFRESH_WAIT_TIMEOUT_SECONDS = 60;
 const REFRESH_LOCK_TTL_BUFFER_MS = 5000;
+const REFRESH_WAIT_GRACE_MS = 2000;
 
 function parseTimeoutSecondsToMs(value: string | undefined, fallbackMs: number): number {
   const parsedSeconds = Number.parseInt(value ?? "", 10);
@@ -40,10 +41,12 @@ const OAUTH_REQUEST_TIMEOUT_MS = parseTimeoutSecondsToMs(
   DEFAULT_OAUTH_REQUEST_TIMEOUT_SECONDS * 1000,
 );
 const REFRESH_LOCK_TTL_MS = OAUTH_REQUEST_TIMEOUT_MS + REFRESH_LOCK_TTL_BUFFER_MS;
-const REFRESH_WAIT_MS = parseTimeoutSecondsToMs(
+const configuredRefreshWaitMs = parseTimeoutSecondsToMs(
   process.env.ONEDRIVE_REFRESH_WAIT_TIMEOUT_SECONDS,
   DEFAULT_REFRESH_WAIT_TIMEOUT_SECONDS * 1000,
 );
+// lock TTL 直後の観測揺れで failure を取りこぼさないよう、follower 待機は lock TTL よりわずかに長く確保する。
+const REFRESH_WAIT_MS = Math.max(configuredRefreshWaitMs, REFRESH_LOCK_TTL_MS + REFRESH_WAIT_GRACE_MS);
 const REFRESH_FAILURE_TTL_SECONDS = Math.ceil(REFRESH_WAIT_MS / 1000);
 
 // Microsoft Entra ID の token endpoint が返すレスポンスのうち、本実装で使う項目だけを表す。

--- a/app/services/onedrive-auth.server.ts
+++ b/app/services/onedrive-auth.server.ts
@@ -232,7 +232,15 @@ async function refreshAccessTokenForSession(sessionId: string, refreshToken: str
     } catch (error) {
       if (!(error instanceof OAuthSessionStoreUnavailableError)) {
         const message = error instanceof Error ? error.message : String(error);
-        await storeRefreshFailure(sessionId, message, REFRESH_FAILURE_TTL_SECONDS);
+        try {
+          await storeRefreshFailure(sessionId, message, REFRESH_FAILURE_TTL_SECONDS);
+        } catch (storeError) {
+          // failure 共有の保存はベストエフォート。元の refresh 失敗理由を優先する。
+          logger.warn("Failed to store OneDrive refresh failure.", {
+            sessionId,
+            error: storeError instanceof Error ? storeError.message : String(storeError),
+          });
+        }
       }
       throw error;
     } finally {

--- a/app/services/onedrive-oauth-session.server.test.ts
+++ b/app/services/onedrive-oauth-session.server.test.ts
@@ -1,0 +1,109 @@
+/**
+ * OneDrive OAuth セッションストアのテスト
+ *
+ * このファイルを用意した理由:
+ * - session store preflight と refresh follower 経路での Redis 障害正規化契約を固定するため。
+ *
+ * このファイルが使われる場面:
+ * - `ensureOAuthSessionStoreAvailable` が write/read/delete probe を行うか確認するとき。
+ * - `waitForRefreshOutcome` が Redis read 障害を `OAuthSessionStoreUnavailableError` として返すか確認するとき。
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { redisMockState } = vi.hoisted(() => ({
+  redisMockState: {
+    deletedProbeKeys: [] as string[],
+    probeReadValueOverride: null as string | null,
+    probeStoredValue: null as string | null,
+    probeWriteError: null as Error | null,
+    refreshFailureReadError: null as Error | null,
+  },
+}));
+
+vi.mock("./redis.server", () => ({
+  redisCompareAndDelete: vi.fn(),
+  redisDel: vi.fn(async (key: string) => {
+    if (key.startsWith("onedrive:probe:")) {
+      redisMockState.deletedProbeKeys.push(key);
+      redisMockState.probeStoredValue = null;
+    }
+  }),
+  redisSetEx: vi.fn(async (key: string, value: string) => {
+    if (key.startsWith("onedrive:probe:")) {
+      if (redisMockState.probeWriteError) {
+        throw redisMockState.probeWriteError;
+      }
+      redisMockState.probeStoredValue = value;
+    }
+  }),
+  redisSetNxPx: vi.fn(),
+  redisGet: vi.fn(async (key: string) => {
+    if (key.startsWith("onedrive:probe:")) {
+      return redisMockState.probeReadValueOverride ?? redisMockState.probeStoredValue;
+    }
+    if (key.startsWith("onedrive:refresh-failure:") && redisMockState.refreshFailureReadError) {
+      throw redisMockState.refreshFailureReadError;
+    }
+    return null;
+  }),
+}));
+
+import {
+  ensureOAuthSessionStoreAvailable,
+  isOAuthSessionStoreUnavailableError,
+  waitForRefreshOutcome,
+} from "./onedrive-oauth-session.server";
+
+describe("onedrive-oauth-session", () => {
+  beforeEach(() => {
+    redisMockState.deletedProbeKeys.length = 0;
+    redisMockState.probeReadValueOverride = null;
+    redisMockState.probeStoredValue = null;
+    redisMockState.probeWriteError = null;
+    redisMockState.refreshFailureReadError = null;
+  });
+
+  it("session store preflight は write/read/delete probe を通す", async () => {
+    await ensureOAuthSessionStoreAvailable();
+
+    expect(redisMockState.deletedProbeKeys).toHaveLength(1);
+    expect(redisMockState.deletedProbeKeys[0]).toMatch(/^onedrive:probe:/);
+    expect(redisMockState.probeStoredValue).toBeNull();
+  });
+
+  it("session store preflight の write 障害は専用エラーに正規化する", async () => {
+    redisMockState.probeWriteError = new Error("redis write denied");
+
+    await expect(ensureOAuthSessionStoreAvailable()).rejects.toSatisfy((error: unknown) => {
+      expect(isOAuthSessionStoreUnavailableError(error)).toBe(true);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("Redis session store probe failed");
+      expect((error as Error).message).toContain("redis write denied");
+      return true;
+    });
+  });
+
+  it("session store preflight の read 不整合は専用エラーに正規化する", async () => {
+    redisMockState.probeReadValueOverride = "unexpected";
+
+    await expect(ensureOAuthSessionStoreAvailable()).rejects.toSatisfy((error: unknown) => {
+      expect(isOAuthSessionStoreUnavailableError(error)).toBe(true);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("Redis session store probe failed");
+      expect((error as Error).message).toContain("unexpected value");
+      return true;
+    });
+  });
+
+  it("refresh failure 読み取りの Redis 障害は専用エラーに正規化する", async () => {
+    redisMockState.refreshFailureReadError = new Error("redis timed out");
+
+    await expect(waitForRefreshOutcome("session-1", 1000)).rejects.toSatisfy((error: unknown) => {
+      expect(isOAuthSessionStoreUnavailableError(error)).toBe(true);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("Redis session store read-refresh-failure failed");
+      expect((error as Error).message).toContain("redis timed out");
+      return true;
+    });
+  });
+});

--- a/app/services/onedrive-oauth-session.server.test.ts
+++ b/app/services/onedrive-oauth-session.server.test.ts
@@ -21,6 +21,7 @@ const { redisMockState } = vi.hoisted(() => ({
     refreshLockValue: null as string | null,
     refreshFailureReadError: null as Error | null,
     refreshLockReadError: null as Error | null,
+    redisGetCallCount: 0,
   },
 }));
 
@@ -42,6 +43,7 @@ vi.mock("./redis.server", () => ({
   }),
   redisSetNxPx: vi.fn(),
   redisGet: vi.fn(async (key: string) => {
+    redisMockState.redisGetCallCount += 1;
     if (key.startsWith("onedrive:probe:")) {
       return redisMockState.probeReadValueOverride ?? redisMockState.probeStoredValue;
     }
@@ -81,6 +83,7 @@ describe("onedrive-oauth-session", () => {
     redisMockState.refreshLockValue = null;
     redisMockState.refreshFailureReadError = null;
     redisMockState.refreshLockReadError = null;
+    redisMockState.redisGetCallCount = 0;
   });
 
   it("session store preflight は write/read/delete probe を通す", async () => {
@@ -150,5 +153,17 @@ describe("onedrive-oauth-session", () => {
         expiresAt: expect.any(Number),
       },
     });
+  });
+
+  it("待機ポーリングは指数バックオフで Redis read 回数を抑える", async () => {
+    vi.useFakeTimers();
+    try {
+      const promise = waitForRefreshOutcome("session-backoff", 500);
+      await vi.advanceTimersByTimeAsync(1000);
+      await expect(promise).resolves.toBeNull();
+      expect(redisMockState.redisGetCallCount).toBeLessThanOrEqual(6);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/app/services/onedrive-oauth-session.server.test.ts
+++ b/app/services/onedrive-oauth-session.server.test.ts
@@ -21,6 +21,9 @@ const { redisMockState } = vi.hoisted(() => ({
     refreshLockValue: null as string | null,
     refreshFailureReadError: null as Error | null,
     refreshLockReadError: null as Error | null,
+    sessionReadError: null as Error | null,
+    sessionDeleteError: null as Error | null,
+    deletedSessionKeys: [] as string[],
     redisGetCallCount: 0,
   },
 }));
@@ -31,6 +34,13 @@ vi.mock("./redis.server", () => ({
     if (key.startsWith("onedrive:probe:")) {
       redisMockState.deletedProbeKeys.push(key);
       redisMockState.probeStoredValue = null;
+    }
+    if (key.startsWith("onedrive:session:")) {
+      if (redisMockState.sessionDeleteError) {
+        throw redisMockState.sessionDeleteError;
+      }
+      redisMockState.deletedSessionKeys.push(key);
+      redisMockState.sessionRawValue = null;
     }
   }),
   redisSetEx: vi.fn(async (key: string, value: string) => {
@@ -48,6 +58,9 @@ vi.mock("./redis.server", () => ({
       return redisMockState.probeReadValueOverride ?? redisMockState.probeStoredValue;
     }
     if (key.startsWith("onedrive:session:")) {
+      if (redisMockState.sessionReadError) {
+        throw redisMockState.sessionReadError;
+      }
       return redisMockState.sessionRawValue;
     }
     if (key.startsWith("onedrive:refresh-failure:") && redisMockState.refreshFailureReadError) {
@@ -68,6 +81,7 @@ vi.mock("./redis.server", () => ({
 
 import {
   ensureOAuthSessionStoreAvailable,
+  getTokenForSession,
   isOAuthSessionStoreUnavailableError,
   waitForRefreshOutcome,
 } from "./onedrive-oauth-session.server";
@@ -83,6 +97,9 @@ describe("onedrive-oauth-session", () => {
     redisMockState.refreshLockValue = null;
     redisMockState.refreshFailureReadError = null;
     redisMockState.refreshLockReadError = null;
+    redisMockState.sessionReadError = null;
+    redisMockState.sessionDeleteError = null;
+    redisMockState.deletedSessionKeys.length = 0;
     redisMockState.redisGetCallCount = 0;
   });
 
@@ -165,5 +182,37 @@ describe("onedrive-oauth-session", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("session JSON 破損は 503 ではなく null を返し、破損キーを削除する", async () => {
+    redisMockState.sessionRawValue = "{broken-json";
+    await expect(getTokenForSession("session-corrupted-json")).resolves.toBeNull();
+    expect(redisMockState.deletedSessionKeys).toContain("onedrive:session:session-corrupted-json");
+  });
+
+  it("session 値が型不整合なら null を返し、破損キーを削除する", async () => {
+    redisMockState.sessionRawValue = JSON.stringify({
+      accessToken: 123,
+      refreshToken: "refresh-token-1",
+      expiresAt: Date.now() + 60_000,
+    });
+    await expect(getTokenForSession("session-invalid-shape")).resolves.toBeNull();
+    expect(redisMockState.deletedSessionKeys).toContain("onedrive:session:session-invalid-shape");
+  });
+
+  it("破損セッション削除が失敗しても null を返す", async () => {
+    redisMockState.sessionRawValue = "{broken-json";
+    redisMockState.sessionDeleteError = new Error("delete failed");
+    await expect(getTokenForSession("session-delete-failed")).resolves.toBeNull();
+  });
+
+  it("session read の Redis 障害だけを専用エラーに正規化する", async () => {
+    redisMockState.sessionReadError = new Error("redis read timed out");
+    await expect(getTokenForSession("session-read-error")).rejects.toSatisfy((error: unknown) => {
+      expect(isOAuthSessionStoreUnavailableError(error)).toBe(true);
+      expect((error as Error).message).toContain("Redis session store read failed");
+      expect((error as Error).message).toContain("redis read timed out");
+      return true;
+    });
   });
 });

--- a/app/services/onedrive-oauth-session.server.test.ts
+++ b/app/services/onedrive-oauth-session.server.test.ts
@@ -16,7 +16,11 @@ const { redisMockState } = vi.hoisted(() => ({
     probeReadValueOverride: null as string | null,
     probeStoredValue: null as string | null,
     probeWriteError: null as Error | null,
+    sessionRawValue: null as string | null,
+    refreshFailureValue: null as string | null,
+    refreshLockValue: null as string | null,
     refreshFailureReadError: null as Error | null,
+    refreshLockReadError: null as Error | null,
   },
 }));
 
@@ -41,8 +45,20 @@ vi.mock("./redis.server", () => ({
     if (key.startsWith("onedrive:probe:")) {
       return redisMockState.probeReadValueOverride ?? redisMockState.probeStoredValue;
     }
+    if (key.startsWith("onedrive:session:")) {
+      return redisMockState.sessionRawValue;
+    }
     if (key.startsWith("onedrive:refresh-failure:") && redisMockState.refreshFailureReadError) {
       throw redisMockState.refreshFailureReadError;
+    }
+    if (key.startsWith("onedrive:refresh-failure:")) {
+      return redisMockState.refreshFailureValue;
+    }
+    if (key.startsWith("onedrive:refresh-lock:") && redisMockState.refreshLockReadError) {
+      throw redisMockState.refreshLockReadError;
+    }
+    if (key.startsWith("onedrive:refresh-lock:")) {
+      return redisMockState.refreshLockValue;
     }
     return null;
   }),
@@ -60,7 +76,11 @@ describe("onedrive-oauth-session", () => {
     redisMockState.probeReadValueOverride = null;
     redisMockState.probeStoredValue = null;
     redisMockState.probeWriteError = null;
+    redisMockState.sessionRawValue = null;
+    redisMockState.refreshFailureValue = null;
+    redisMockState.refreshLockValue = null;
     redisMockState.refreshFailureReadError = null;
+    redisMockState.refreshLockReadError = null;
   });
 
   it("session store preflight は write/read/delete probe を通す", async () => {
@@ -104,6 +124,31 @@ describe("onedrive-oauth-session", () => {
       expect((error as Error).message).toContain("Redis session store read-refresh-failure failed");
       expect((error as Error).message).toContain("redis timed out");
       return true;
+    });
+  });
+
+  it("lock 存在中の stale refresh failure では即失敗せず、成功 token を優先する", async () => {
+    const sessionId = "session-stale-failure";
+    redisMockState.refreshFailureValue = "stale failure";
+    redisMockState.refreshLockValue = "lock-token";
+
+    setTimeout(() => {
+      redisMockState.sessionRawValue = JSON.stringify({
+        accessToken: "new-access-token",
+        refreshToken: "refresh-token-2",
+        expiresAt: Date.now() + 60_000,
+      });
+      redisMockState.refreshFailureValue = null;
+      redisMockState.refreshLockValue = null;
+    }, 20);
+
+    await expect(waitForRefreshOutcome(sessionId, 500)).resolves.toEqual({
+      kind: "token",
+      token: {
+        accessToken: "new-access-token",
+        refreshToken: "refresh-token-2",
+        expiresAt: expect.any(Number),
+      },
     });
   });
 });

--- a/app/services/onedrive-oauth-session.server.ts
+++ b/app/services/onedrive-oauth-session.server.ts
@@ -165,6 +165,16 @@ async function getRefreshFailure(sessionId: string): Promise<string | null> {
   }
 }
 
+// stale refresh failure 誤検知を避けるため、follower は lock の有無も参照して確定失敗か判定する。
+async function hasActiveRefreshLock(sessionId: string): Promise<boolean> {
+  try {
+    const lockToken = await redisGet(toRefreshLockKey(sessionId));
+    return Boolean(lockToken);
+  } catch (error) {
+    throw toStoreUnavailableError("read-refresh-lock", error);
+  }
+}
+
 export type RefreshOutcome =
   | { kind: "token"; token: TokenCache }
   | { kind: "error"; message: string };
@@ -180,7 +190,9 @@ export async function waitForRefreshOutcome(sessionId: string, waitMs: number): 
 
     const refreshFailure = await getRefreshFailure(sessionId);
     if (refreshFailure) {
-      return { kind: "error", message: refreshFailure };
+      if (!(await hasActiveRefreshLock(sessionId))) {
+        return { kind: "error", message: refreshFailure };
+      }
     }
 
     await sleep(REFRESH_LOCK_POLL_MS);

--- a/app/services/onedrive-oauth-session.server.ts
+++ b/app/services/onedrive-oauth-session.server.ts
@@ -94,19 +94,46 @@ export async function storeTokenForSession(sessionId: string, cache: TokenCache)
   }
 }
 
+// 破損セッションの cleanup はベストエフォートで行い、認証切れ扱いを優先する。
+async function deleteCorruptedSessionKey(sessionId: string): Promise<void> {
+  try {
+    await redisDel(toSessionKey(sessionId));
+  } catch {
+    // cleanup 失敗は握りつぶし、元の処理結果を優先する。
+  }
+}
+
 // Redis から読んだ JSON を最低限検証し、壊れた値をそのまま業務ロジックへ渡さない。
 export async function getTokenForSession(sessionId: string | null): Promise<TokenCache | null> {
   if (!sessionId) return null;
+
+  let raw: string | null;
   try {
-    const raw = await redisGet(toSessionKey(sessionId));
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as TokenCache;
-    if (typeof parsed.accessToken !== "string") return null;
-    if (parsed.refreshToken !== null && typeof parsed.refreshToken !== "string") return null;
-    if (typeof parsed.expiresAt !== "number" || !Number.isFinite(parsed.expiresAt)) return null;
-    return parsed;
+    raw = await redisGet(toSessionKey(sessionId));
   } catch (error) {
     throw toStoreUnavailableError("read", error);
+  }
+
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as TokenCache;
+    if (typeof parsed.accessToken !== "string") {
+      await deleteCorruptedSessionKey(sessionId);
+      return null;
+    }
+    if (parsed.refreshToken !== null && typeof parsed.refreshToken !== "string") {
+      await deleteCorruptedSessionKey(sessionId);
+      return null;
+    }
+    if (typeof parsed.expiresAt !== "number" || !Number.isFinite(parsed.expiresAt)) {
+      await deleteCorruptedSessionKey(sessionId);
+      return null;
+    }
+    return parsed;
+  } catch {
+    await deleteCorruptedSessionKey(sessionId);
+    return null;
   }
 }
 

--- a/app/services/onedrive-oauth-session.server.ts
+++ b/app/services/onedrive-oauth-session.server.ts
@@ -1,0 +1,189 @@
+/**
+ * OneDrive OAuth セッションストア
+ *
+ * このファイルを用意した理由:
+ * - OneDrive OAuth の token cache と refresh ロックを Redis ベースで一元管理するため。
+ * - Redis 障害を OAuth 認証エラーと分離し、専用エラーへ正規化するため。
+ *
+ * このファイルが使われる場面:
+ * - callback 後に access token / refresh token を保存するとき。
+ * - API 実行時に sessionId から token cache を参照するとき。
+ * - 複数インスタンスで token refresh の多重実行を抑止するとき。
+ */
+import { redisCompareAndDelete, redisDel, redisGet, redisSetEx, redisSetNxPx } from "./redis.server";
+
+const SESSION_TTL_SECONDS = 60 * 60 * 24 * 7;
+const REFRESH_LOCK_POLL_MS = 100;
+const STORE_PROBE_TTL_SECONDS = 5;
+const SESSION_KEY_PREFIX = "onedrive:session:";
+const STORE_PROBE_KEY_PREFIX = "onedrive:probe:";
+const REFRESH_LOCK_KEY_PREFIX = "onedrive:refresh-lock:";
+const REFRESH_FAILURE_KEY_PREFIX = "onedrive:refresh-failure:";
+
+// OneDrive OAuth の server-side session に保存する最小契約。
+export type TokenCache = {
+  accessToken: string;
+  refreshToken: string | null;
+  expiresAt: number;
+};
+
+// Redis 障害を認証切れと区別するための専用エラー。
+export class OAuthSessionStoreUnavailableError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "OAuthSessionStoreUnavailableError";
+  }
+}
+// OAuthSessionStoreUnavailableError 型ガード。これを使うことで、呼び出し側は Redis 障害と認証エラーを明確に分けて扱えるようになる。
+export function isOAuthSessionStoreUnavailableError(error: unknown): error is OAuthSessionStoreUnavailableError {
+  return error instanceof OAuthSessionStoreUnavailableError;
+}
+
+// Redis 上の key 命名規則を閉じ込め、呼び出し側に prefix 知識を漏らさない。
+function toSessionKey(sessionId: string): string {
+  return `${SESSION_KEY_PREFIX}${sessionId}`;
+}
+
+function toStoreProbeKey(probeId: string): string {
+  return `${STORE_PROBE_KEY_PREFIX}${probeId}`;
+}
+
+function toRefreshLockKey(sessionId: string): string {
+  return `${REFRESH_LOCK_KEY_PREFIX}${sessionId}`;
+}
+
+function toRefreshFailureKey(sessionId: string): string {
+  return `${REFRESH_FAILURE_KEY_PREFIX}${sessionId}`;
+}
+
+// Redis 例外を OAuth 専用のインフラ障害へ変換し、UI 側の扱いを一貫させる。
+function toStoreUnavailableError(action: string, error: unknown): OAuthSessionStoreUnavailableError {
+  const message = error instanceof Error ? error.message : String(error);
+  return new OAuthSessionStoreUnavailableError(`Redis session store ${action} failed: ${message}`, {
+    cause: error,
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+// 以下、Redis ストアを経由した OneDrive OAuth token 永続化の実装。呼び出し側はこれらの関数を通じて sessionId と token cache をやりとりする。
+export async function ensureOAuthSessionStoreAvailable(): Promise<void> {
+  const probeId = crypto.randomUUID();
+  const probeKey = toStoreProbeKey(probeId);
+  try {
+    await redisSetEx(probeKey, probeId, STORE_PROBE_TTL_SECONDS);
+    const storedValue = await redisGet(probeKey);
+    if (storedValue !== probeId) {
+      throw new Error("Redis session store probe returned an unexpected value");
+    }
+    await redisDel(probeKey);
+  } catch (error) {
+    throw toStoreUnavailableError("probe", error);
+  }
+}
+
+export async function storeTokenForSession(sessionId: string, cache: TokenCache): Promise<void> {
+  try {
+    await redisSetEx(toSessionKey(sessionId), JSON.stringify(cache), SESSION_TTL_SECONDS);
+  } catch (error) {
+    throw toStoreUnavailableError("write", error);
+  }
+}
+
+// Redis から読んだ JSON を最低限検証し、壊れた値をそのまま業務ロジックへ渡さない。
+export async function getTokenForSession(sessionId: string | null): Promise<TokenCache | null> {
+  if (!sessionId) return null;
+  try {
+    const raw = await redisGet(toSessionKey(sessionId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as TokenCache;
+    if (typeof parsed.accessToken !== "string") return null;
+    if (parsed.refreshToken !== null && typeof parsed.refreshToken !== "string") return null;
+    if (typeof parsed.expiresAt !== "number" || !Number.isFinite(parsed.expiresAt)) return null;
+    return parsed;
+  } catch (error) {
+    throw toStoreUnavailableError("read", error);
+  }
+}
+
+export async function deleteTokenForSession(sessionId: string): Promise<void> {
+  try {
+    await redisDel(toSessionKey(sessionId));
+  } catch (error) {
+    throw toStoreUnavailableError("delete", error);
+  }
+}
+
+// refresh を実行する worker だけが続行できるよう、トークン付きロックを返す。
+// TTL は呼び出し元が refresh の最長実行時間に合わせて渡す。
+export async function tryAcquireRefreshLock(sessionId: string, ttlMs: number): Promise<string | null> {
+  const token = crypto.randomUUID();
+  try {
+    const acquired = await redisSetNxPx(toRefreshLockKey(sessionId), token, ttlMs);
+    return acquired ? token : null;
+  } catch (error) {
+    throw toStoreUnavailableError("lock", error);
+  }
+}
+
+// compare-and-delete で、自分が取ったロックだけを安全に解放する。
+export async function releaseRefreshLock(sessionId: string, lockToken: string): Promise<void> {
+  try {
+    await redisCompareAndDelete(toRefreshLockKey(sessionId), lockToken);
+  } catch (error) {
+    throw toStoreUnavailableError("unlock", error);
+  }
+}
+
+// 新しい refresh の開始前に前回失敗結果を消し、古い失敗情報を後続へ誤配信しない。
+export async function clearRefreshFailure(sessionId: string): Promise<void> {
+  try {
+    await redisDel(toRefreshFailureKey(sessionId));
+  } catch (error) {
+    throw toStoreUnavailableError("clear-refresh-failure", error);
+  }
+}
+
+// 先行 worker の refresh 失敗を短期保存し、後続 worker に同じ失敗理由を返せるようにする。
+export async function storeRefreshFailure(sessionId: string, message: string, ttlSeconds: number): Promise<void> {
+  try {
+    await redisSetEx(toRefreshFailureKey(sessionId), message, ttlSeconds);
+  } catch (error) {
+    throw toStoreUnavailableError("write-refresh-failure", error);
+  }
+}
+
+// refresh failure 読み取りも専用エラーへ正規化し、follower 側で Redis 障害を取りこぼさない。
+async function getRefreshFailure(sessionId: string): Promise<string | null> {
+  try {
+    return await redisGet(toRefreshFailureKey(sessionId));
+  } catch (error) {
+    throw toStoreUnavailableError("read-refresh-failure", error);
+  }
+}
+
+export type RefreshOutcome =
+  | { kind: "token"; token: TokenCache }
+  | { kind: "error"; message: string };
+
+// 他 worker の refresh 完了または失敗を待ち、結果が出たら同じ outcome を返す。
+export async function waitForRefreshOutcome(sessionId: string, waitMs: number): Promise<RefreshOutcome | null> {
+  const deadline = Date.now() + waitMs;
+  while (Date.now() < deadline) {
+    const token = await getTokenForSession(sessionId);
+    if (token && token.expiresAt > Date.now()) {
+      return { kind: "token", token };
+    }
+
+    const refreshFailure = await getRefreshFailure(sessionId);
+    if (refreshFailure) {
+      return { kind: "error", message: refreshFailure };
+    }
+
+    await sleep(REFRESH_LOCK_POLL_MS);
+  }
+  return null;
+}

--- a/app/services/onedrive-oauth-session.server.ts
+++ b/app/services/onedrive-oauth-session.server.ts
@@ -13,7 +13,8 @@
 import { redisCompareAndDelete, redisDel, redisGet, redisSetEx, redisSetNxPx } from "./redis.server";
 
 const SESSION_TTL_SECONDS = 60 * 60 * 24 * 7;
-const REFRESH_LOCK_POLL_MS = 100;
+const REFRESH_LOCK_POLL_INITIAL_MS = 100;
+const REFRESH_LOCK_POLL_MAX_MS = 1000;
 const STORE_PROBE_TTL_SECONDS = 5;
 const SESSION_KEY_PREFIX = "onedrive:session:";
 const STORE_PROBE_KEY_PREFIX = "onedrive:probe:";
@@ -182,6 +183,7 @@ export type RefreshOutcome =
 // 他 worker の refresh 完了または失敗を待ち、結果が出たら同じ outcome を返す。
 export async function waitForRefreshOutcome(sessionId: string, waitMs: number): Promise<RefreshOutcome | null> {
   const deadline = Date.now() + waitMs;
+  let pollMs = REFRESH_LOCK_POLL_INITIAL_MS;
   while (Date.now() < deadline) {
     const token = await getTokenForSession(sessionId);
     if (token && token.expiresAt > Date.now()) {
@@ -195,7 +197,8 @@ export async function waitForRefreshOutcome(sessionId: string, waitMs: number): 
       }
     }
 
-    await sleep(REFRESH_LOCK_POLL_MS);
+    await sleep(pollMs);
+    pollMs = Math.min(REFRESH_LOCK_POLL_MAX_MS, pollMs * 2);
   }
   return null;
 }

--- a/app/services/onedrive.server.ts
+++ b/app/services/onedrive.server.ts
@@ -620,12 +620,16 @@ export async function createOneDriveServiceFromEnv(request?: Request): Promise<O
   const accessToken = process.env.ONEDRIVE_ACCESS_TOKEN ?? "";
   // request がある API 経路では、必ずその request の OAuth セッションを使う。
   const { getAccessToken } = await import("./onedrive-auth.server");
+  const { isOAuthSessionStoreUnavailableError } = await import("./onedrive-oauth-session.server");
 
   if (request) {
     try {
       const oauthToken = await getAccessToken(request);
       return createOneDriveService({ accessToken: oauthToken });
     } catch (oauthError) {
+      if (isOAuthSessionStoreUnavailableError(oauthError)) {
+        throw oauthError;
+      }
       const reason = oauthError instanceof Error ? oauthError.message : String(oauthError);
       throw new Error(
         `OneDrive OAuth セッションからアクセストークンを取得できませんでした: ${reason} ` +

--- a/app/services/redis.server.test.ts
+++ b/app/services/redis.server.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Redis 接続ユーティリティのテスト
+ *
+ * このファイルを用意した理由:
+ * - Redis connect / command timeout 時に socket が確実に cleanup される契約を固定するため。
+ *
+ * このファイルが使われる場面:
+ * - Redis 障害時に socket leak を起こさないことを確認するとき。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSocketState } = vi.hoisted(() => ({
+  mockSocketState: {
+    mode: "connect-timeout" as "connect-timeout" | "command-timeout",
+    sockets: [] as Array<{ destroyedByTest: boolean; endedByTest: boolean }>,
+  },
+}));
+
+vi.mock("node:net", async () => {
+  const { EventEmitter } = await import("node:events");
+  class MockSocket extends EventEmitter {
+    destroyedByTest = false;
+    endedByTest = false;
+
+    constructor() {
+      super();
+      mockSocketState.sockets.push(this);
+    }
+
+    connect(_port: number, _host: string) {
+      if (mockSocketState.mode === "command-timeout") {
+        setTimeout(() => {
+          this.emit("connect");
+        }, 0);
+      }
+      return this;
+    }
+
+    write(_chunk: Buffer) {
+      return true;
+    }
+
+    destroy() {
+      this.destroyedByTest = true;
+      this.emit("close");
+      return this;
+    }
+
+    end() {
+      this.endedByTest = true;
+      this.emit("close");
+      return this;
+    }
+  }
+
+  return { Socket: MockSocket };
+});
+
+vi.mock("node:tls", async () => {
+  const { EventEmitter } = await import("node:events");
+  class MockTlsSocket extends EventEmitter {
+    destroyedByTest = false;
+    endedByTest = false;
+
+    constructor() {
+      super();
+      mockSocketState.sockets.push(this);
+    }
+
+    write(_chunk: Buffer) {
+      return true;
+    }
+
+    destroy() {
+      this.destroyedByTest = true;
+      this.emit("close");
+      return this;
+    }
+
+    end() {
+      this.endedByTest = true;
+      this.emit("close");
+      return this;
+    }
+  }
+
+  return {
+    connect: vi.fn(() => new MockTlsSocket()),
+  };
+});
+
+import { redisPing } from "./redis.server";
+
+describe("redis.server timeout cleanup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    process.env.REDIS_URL = "redis://localhost:6379/0";
+    process.env.REDIS_TIMEOUT_MS = "10";
+    mockSocketState.sockets.length = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete process.env.REDIS_URL;
+    delete process.env.REDIS_TIMEOUT_MS;
+    mockSocketState.sockets.length = 0;
+  });
+
+  it("connect timeout時はsocketをdestroyする", async () => {
+    mockSocketState.mode = "connect-timeout";
+
+    const promise = redisPing();
+    const rejection = expect(promise).rejects.toThrow("Redis connect timed out after 10ms");
+    await vi.advanceTimersByTimeAsync(11);
+
+    await rejection;
+    expect(mockSocketState.sockets).toHaveLength(1);
+    expect(mockSocketState.sockets[0].destroyedByTest).toBe(true);
+  });
+
+  it("command timeout時はsocketをdestroyする", async () => {
+    mockSocketState.mode = "command-timeout";
+
+    const promise = redisPing();
+    const rejection = expect(promise).rejects.toThrow("Redis command timed out after 10ms");
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(10);
+
+    await rejection;
+    expect(mockSocketState.sockets).toHaveLength(1);
+    expect(mockSocketState.sockets[0].destroyedByTest).toBe(true);
+    expect(mockSocketState.sockets[0].endedByTest).toBe(false);
+  });
+});

--- a/app/services/redis.server.test.ts
+++ b/app/services/redis.server.test.ts
@@ -11,7 +11,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockSocketState } = vi.hoisted(() => ({
   mockSocketState: {
-    mode: "connect-timeout" as "connect-timeout" | "command-timeout" | "post-connect-sync-error",
+    mode:
+      "connect-timeout" as
+        | "connect-timeout"
+        | "command-timeout"
+        | "post-connect-sync-error"
+        | "post-connect-async-error-close-fallback",
     sockets: [] as Array<{ destroyedByTest: boolean; endedByTest: boolean }>,
   },
 }));
@@ -21,6 +26,7 @@ vi.mock("node:net", async () => {
   class MockSocket extends EventEmitter {
     destroyedByTest = false;
     endedByTest = false;
+    errorOnceRegistrations = 0;
 
     constructor() {
       super();
@@ -35,8 +41,27 @@ vi.mock("node:net", async () => {
       } else if (mockSocketState.mode === "post-connect-sync-error") {
         this.emit("connect");
         this.emit("error", new Error("ECONNRESET after connect"));
+      } else if (mockSocketState.mode === "post-connect-async-error-close-fallback") {
+        this.emit("connect");
+        setTimeout(() => {
+          this.emit("error", new Error("ECONNRESET after connect async"));
+        }, 0);
       }
       return this;
+    }
+
+    once(eventName: string | symbol, listener: (...args: any[]) => void) {
+      if (eventName === "error") {
+        this.errorOnceRegistrations += 1;
+        // openSocket の error listener は残しつつ、runSequence 側 listener だけ未登録を再現する。
+        if (
+          mockSocketState.mode === "post-connect-async-error-close-fallback" &&
+          this.errorOnceRegistrations >= 2
+        ) {
+          return this;
+        }
+      }
+      return super.once(eventName, listener);
     }
 
     write(_chunk: Buffer) {
@@ -139,6 +164,17 @@ describe("redis.server timeout cleanup", () => {
     mockSocketState.mode = "post-connect-sync-error";
 
     await expect(redisPing()).rejects.toThrow("ECONNRESET after connect");
+    expect(mockSocketState.sockets).toHaveLength(1);
+    expect(mockSocketState.sockets[0].destroyedByTest).toBe(true);
+  });
+
+  it("connect直後の非同期errorは close 経由でも原因errorを優先して返す", async () => {
+    mockSocketState.mode = "post-connect-async-error-close-fallback";
+
+    const promise = redisPing();
+    const rejection = expect(promise).rejects.toThrow("ECONNRESET after connect async");
+    await vi.advanceTimersByTimeAsync(1);
+    await rejection;
     expect(mockSocketState.sockets).toHaveLength(1);
     expect(mockSocketState.sockets[0].destroyedByTest).toBe(true);
   });

--- a/app/services/redis.server.test.ts
+++ b/app/services/redis.server.test.ts
@@ -150,6 +150,13 @@ describe("redis.server timeout cleanup", () => {
     expect(mockSocketState.sockets).toHaveLength(0);
   });
 
+  it("REDIS_URL の DB path が不正なら明確な設定エラーを返す", async () => {
+    process.env.REDIS_URL = "redis://localhost:6379/0/extra";
+
+    await expect(redisPing()).rejects.toThrow("REDIS_URL database index is invalid. Use /<non-negative-integer>.");
+    expect(mockSocketState.sockets).toHaveLength(0);
+  });
+
   it("password に % が含まれても URIError にならず接続処理へ進む", async () => {
     mockSocketState.mode = "command-timeout";
     process.env.REDIS_URL = "redis://user:pa%ss@localhost:6379/0";

--- a/app/services/redis.server.test.ts
+++ b/app/services/redis.server.test.ts
@@ -11,7 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockSocketState } = vi.hoisted(() => ({
   mockSocketState: {
-    mode: "connect-timeout" as "connect-timeout" | "command-timeout",
+    mode: "connect-timeout" as "connect-timeout" | "command-timeout" | "post-connect-sync-error",
     sockets: [] as Array<{ destroyedByTest: boolean; endedByTest: boolean }>,
   },
 }));
@@ -32,6 +32,9 @@ vi.mock("node:net", async () => {
         setTimeout(() => {
           this.emit("connect");
         }, 0);
+      } else if (mockSocketState.mode === "post-connect-sync-error") {
+        this.emit("connect");
+        this.emit("error", new Error("ECONNRESET after connect"));
       }
       return this;
     }
@@ -130,5 +133,17 @@ describe("redis.server timeout cleanup", () => {
     expect(mockSocketState.sockets).toHaveLength(1);
     expect(mockSocketState.sockets[0].destroyedByTest).toBe(true);
     expect(mockSocketState.sockets[0].endedByTest).toBe(false);
+  });
+
+  it("connect直後の同期errorでも未処理errorでクラッシュせずに失敗を返す", async () => {
+    mockSocketState.mode = "post-connect-sync-error";
+
+    const promise = redisPing();
+    const rejection = expect(promise).rejects.toThrow("Redis command timed out after 10ms");
+    await vi.advanceTimersByTimeAsync(10);
+
+    await rejection;
+    expect(mockSocketState.sockets).toHaveLength(1);
+    expect(mockSocketState.sockets[0].destroyedByTest).toBe(true);
   });
 });

--- a/app/services/redis.server.test.ts
+++ b/app/services/redis.server.test.ts
@@ -135,14 +135,10 @@ describe("redis.server timeout cleanup", () => {
     expect(mockSocketState.sockets[0].endedByTest).toBe(false);
   });
 
-  it("connect直後の同期errorでも未処理errorでクラッシュせずに失敗を返す", async () => {
+  it("connect直後の同期errorは timeout まで待たずに即失敗する", async () => {
     mockSocketState.mode = "post-connect-sync-error";
 
-    const promise = redisPing();
-    const rejection = expect(promise).rejects.toThrow("Redis command timed out after 10ms");
-    await vi.advanceTimersByTimeAsync(10);
-
-    await rejection;
+    await expect(redisPing()).rejects.toThrow("ECONNRESET after connect");
     expect(mockSocketState.sockets).toHaveLength(1);
     expect(mockSocketState.sockets[0].destroyedByTest).toBe(true);
   });
@@ -152,5 +148,19 @@ describe("redis.server timeout cleanup", () => {
 
     await expect(redisPing()).rejects.toThrow("REDIS_URL port is invalid. Use an integer between 1 and 65535.");
     expect(mockSocketState.sockets).toHaveLength(0);
+  });
+
+  it("password に % が含まれても URIError にならず接続処理へ進む", async () => {
+    mockSocketState.mode = "command-timeout";
+    process.env.REDIS_URL = "redis://user:pa%ss@localhost:6379/0";
+
+    const promise = redisPing();
+    const rejection = expect(promise).rejects.toThrow("Redis command timed out after 10ms");
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(10);
+
+    await rejection;
+    expect(mockSocketState.sockets).toHaveLength(1);
+    expect(mockSocketState.sockets[0].destroyedByTest).toBe(true);
   });
 });

--- a/app/services/redis.server.test.ts
+++ b/app/services/redis.server.test.ts
@@ -146,4 +146,11 @@ describe("redis.server timeout cleanup", () => {
     expect(mockSocketState.sockets).toHaveLength(1);
     expect(mockSocketState.sockets[0].destroyedByTest).toBe(true);
   });
+
+  it("REDIS_URL の port が範囲外なら明確な設定エラーを返す", async () => {
+    process.env.REDIS_URL = "redis://localhost:0/0";
+
+    await expect(redisPing()).rejects.toThrow("REDIS_URL port is invalid. Use an integer between 1 and 65535.");
+    expect(mockSocketState.sockets).toHaveLength(0);
+  });
 });

--- a/app/services/redis.server.ts
+++ b/app/services/redis.server.ts
@@ -147,8 +147,11 @@ function getRedisEndpoint(): RedisEndpoint | null {
     throw new Error("REDIS_URL must use redis:// or rediss://");
   }
 
-  const dbPath = url.pathname.replace(/^\//, "");
-  const db = dbPath ? Number.parseInt(dbPath, 10) : 0;
+  const dbPath = url.pathname;
+  if (dbPath !== "/" && !/^\/\d+$/.test(dbPath)) {
+    throw new Error("REDIS_URL database index is invalid. Use /<non-negative-integer>.");
+  }
+  const db = dbPath === "/" ? 0 : Number.parseInt(dbPath.slice(1), 10);
   if (!Number.isFinite(db) || db < 0) {
     throw new Error("REDIS_URL database index is invalid");
   }

--- a/app/services/redis.server.ts
+++ b/app/services/redis.server.ts
@@ -179,9 +179,10 @@ function openSocket(endpoint: RedisEndpoint, timeoutMs: number): Promise<Socket 
       ? connectTls({ host: endpoint.host, port: endpoint.port, servername: endpoint.host })
       : new Socket();
     const connectEventName = endpoint.tls ? "secureConnect" : "connect";
+    // connect 完了直後の一瞬で error が飛んでも未処理化しないよう、常駐ガードを置く。
+    const onErrorGuard = () => {};
     const cleanup = () => {
       clearTimeout(timer);
-      socket.off("error", onError);
       socket.off(connectEventName, onConnect);
       socket.off("close", onClose);
     };
@@ -214,6 +215,7 @@ function openSocket(endpoint: RedisEndpoint, timeoutMs: number): Promise<Socket 
       });
     }, timeoutMs);
 
+    socket.on("error", onErrorGuard);
     socket.once("error", onError);
     socket.once(connectEventName, onConnect);
     socket.once("close", onClose);

--- a/app/services/redis.server.ts
+++ b/app/services/redis.server.ts
@@ -1,0 +1,347 @@
+/**
+ * Redis 接続ユーティリティ
+ *
+ * このファイルを用意した理由:
+ * - OneDrive OAuth のサーバー側セッションを Redis に保存するための最小クライアントをまとめるため。
+ * - 依存追加に頼らず、必要な Redis コマンドだけを明示的に扱うため。
+ *
+ * このファイルが使われる場面:
+ * - OAuth セッション保存・参照・削除を行うとき。
+ * - token refresh の分散ロックを取得・解放するとき。
+ * - OAuth 開始前に Redis 疎通を確認するとき。
+ */
+import { Socket } from "node:net";
+import { connect as connectTls } from "node:tls";
+import type { TLSSocket } from "node:tls";
+
+const DEFAULT_REDIS_TIMEOUT_MS = 3000;
+
+type RedisEndpoint = {
+  host: string;
+  port: number;
+  db: number;
+  username: string | null;
+  password: string | null;
+  tls: boolean;
+};
+
+// 今回使う RESP の最小表現。bulk string / integer / array だけ扱えれば必要コマンドを解釈できる。
+type RespValue = string | null | number | RespValue[];
+
+// Redis の RESP 応答を逐次パースし、ソケットの chunk 分割を吸収する。
+class RespParser {
+  private buffer = Buffer.alloc(0);
+
+  push(chunk: Buffer) {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+  }
+
+  tryParse(): { value: RespValue; consumed: number } | null {
+    return this.parseAt(0);
+  }
+
+  consume(length: number) {
+    this.buffer = this.buffer.subarray(length);
+  }
+
+  // 先頭1文字の marker を見て、RESP 型ごとのパーサーへ振り分ける。
+  private parseAt(offset: number): { value: RespValue; consumed: number } | null {
+    if (this.buffer.length <= offset) return null;
+    const marker = String.fromCharCode(this.buffer[offset]);
+    switch (marker) {
+      case "+":
+        return this.parseSimpleString(offset);
+      case "-":
+        return this.parseError(offset);
+      case ":":
+        return this.parseInteger(offset);
+      case "$":
+        return this.parseBulkString(offset);
+      case "*":
+        return this.parseArray(offset);
+      default:
+        throw new Error(`Unsupported Redis RESP marker: ${marker}`);
+    }
+  }
+
+  private parseLine(offset: number): { value: string; end: number } | null {
+    const end = this.buffer.indexOf("\r\n", offset);
+    if (end === -1) return null;
+    return {
+      value: this.buffer.toString("utf8", offset, end),
+      end: end + 2,
+    };
+  }
+
+  private parseSimpleString(offset: number): { value: string; consumed: number } | null {
+    const line = this.parseLine(offset + 1);
+    if (!line) return null;
+    return { value: line.value, consumed: line.end - offset };
+  }
+
+  private parseError(offset: number): never | null {
+    const line = this.parseLine(offset + 1);
+    if (!line) return null;
+    throw new Error(`Redis error: ${line.value}`);
+  }
+
+  private parseInteger(offset: number): { value: number; consumed: number } | null {
+    const line = this.parseLine(offset + 1);
+    if (!line) return null;
+    return { value: Number.parseInt(line.value, 10), consumed: line.end - offset };
+  }
+
+  private parseBulkString(offset: number): { value: string | null; consumed: number } | null {
+    const line = this.parseLine(offset + 1);
+    if (!line) return null;
+    const length = Number.parseInt(line.value, 10);
+    if (length === -1) {
+      return { value: null, consumed: line.end - offset };
+    }
+    const bodyStart = line.end;
+    const bodyEnd = bodyStart + length;
+    if (this.buffer.length < bodyEnd + 2) return null;
+    return {
+      value: this.buffer.toString("utf8", bodyStart, bodyEnd),
+      consumed: bodyEnd + 2 - offset,
+    };
+  }
+
+  private parseArray(offset: number): { value: RespValue[]; consumed: number } | null {
+    const line = this.parseLine(offset + 1);
+    if (!line) return null;
+    const length = Number.parseInt(line.value, 10);
+    if (length === -1) {
+      return { value: [], consumed: line.end - offset };
+    }
+
+    let cursor = line.end;
+    const values: RespValue[] = [];
+    for (let i = 0; i < length; i++) {
+      const parsed = this.parseAt(cursor);
+      if (!parsed) return null;
+      values.push(parsed.value);
+      cursor += parsed.consumed;
+    }
+    return { value: values, consumed: cursor - offset };
+  }
+}
+
+function getRedisTimeoutMs(): number {
+  const parsed = Number.parseInt(process.env.REDIS_TIMEOUT_MS ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_REDIS_TIMEOUT_MS;
+  return parsed;
+}
+
+// redis:// / rediss:// を環境変数から解決し、接続に必要な要素へ分解する。
+function getRedisEndpoint(): RedisEndpoint | null {
+  const raw = process.env.REDIS_URL?.trim() ?? "";
+  if (!raw) return null;
+
+  const url = new URL(raw);
+  if (url.protocol !== "redis:" && url.protocol !== "rediss:") {
+    throw new Error("REDIS_URL must use redis:// or rediss://");
+  }
+
+  const dbPath = url.pathname.replace(/^\//, "");
+  const db = dbPath ? Number.parseInt(dbPath, 10) : 0;
+  if (!Number.isFinite(db) || db < 0) {
+    throw new Error("REDIS_URL database index is invalid");
+  }
+
+  return {
+    host: url.hostname || "127.0.0.1",
+    port: url.port ? Number.parseInt(url.port, 10) : 6379,
+    db,
+    username: url.username ? decodeURIComponent(url.username) : null,
+    password: url.password ? decodeURIComponent(url.password) : null,
+    tls: url.protocol === "rediss:",
+  };
+}
+
+// Redis コマンドを RESP 配列形式へエンコードしてソケットへ流せる形にする。
+function encodeCommand(parts: string[]): Buffer {
+  const chunks: Buffer[] = [Buffer.from(`*${parts.length}\r\n`, "utf8")];
+  for (const part of parts) {
+    const body = Buffer.from(part, "utf8");
+    chunks.push(Buffer.from(`$${body.length}\r\n`, "utf8"));
+    chunks.push(body);
+    chunks.push(Buffer.from("\r\n", "utf8"));
+  }
+  return Buffer.concat(chunks);
+}
+
+// Redis への平文/TLS 接続差分をここで吸収し、以降の送受信処理を単純化する。
+function openSocket(endpoint: RedisEndpoint, timeoutMs: number): Promise<Socket | TLSSocket> {
+  return new Promise<Socket | TLSSocket>((resolve, reject) => {
+    let settled = false;
+    const socket = endpoint.tls
+      ? connectTls({ host: endpoint.host, port: endpoint.port, servername: endpoint.host })
+      : new Socket();
+    const connectEventName = endpoint.tls ? "secureConnect" : "connect";
+    const cleanup = () => {
+      clearTimeout(timer);
+      socket.off("error", onError);
+      socket.off(connectEventName, onConnect);
+      socket.off("close", onClose);
+    };
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback();
+    };
+    const onError = (error: Error) => {
+      settle(() => {
+        socket.destroy();
+        reject(error);
+      });
+    };
+    const onConnect = () => {
+      settle(() => {
+        resolve(socket);
+      });
+    };
+    const onClose = () => {
+      settle(() => {
+        reject(new Error("Redis connection closed before connect completed"));
+      });
+    };
+    const timer = setTimeout(() => {
+      settle(() => {
+        socket.destroy();
+        reject(new Error(`Redis connect timed out after ${timeoutMs}ms`));
+      });
+    }, timeoutMs);
+
+    socket.once("error", onError);
+    socket.once(connectEventName, onConnect);
+    socket.once("close", onClose);
+    if (!endpoint.tls) {
+      socket.connect(endpoint.port, endpoint.host);
+    }
+  });
+}
+
+// AUTH/SELECT を含めた複数コマンドを 1 接続で順に流し、RESP でまとめて回収する。
+async function runSequence(sequence: string[][]): Promise<RespValue[]> {
+  const endpoint = getRedisEndpoint();
+  if (!endpoint) {
+    throw new Error("REDIS_URL is not configured");
+  }
+
+  const timeoutMs = getRedisTimeoutMs();
+  const commands: string[][] = [];
+  if (endpoint.password) {
+    commands.push(
+      endpoint.username
+        ? ["AUTH", endpoint.username, endpoint.password]
+        : ["AUTH", endpoint.password],
+    );
+  }
+  if (endpoint.db !== 0) {
+    commands.push(["SELECT", String(endpoint.db)]);
+  }
+  commands.push(...sequence);
+
+  const socket = await openSocket(endpoint, timeoutMs);
+  const parser = new RespParser();
+  const values: RespValue[] = [];
+
+  return await new Promise<RespValue[]>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => {
+      clearTimeout(timer);
+      socket.off("data", onData);
+      socket.off("error", onError);
+      socket.off("close", onClose);
+    };
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback();
+    };
+    const finish = (value: RespValue[]) => {
+      settle(() => {
+        socket.end();
+        resolve(value);
+      });
+    };
+    const fail = (error: Error) => {
+      settle(() => {
+        socket.destroy();
+        reject(error);
+      });
+    };
+    const onData = (chunk: Buffer) => {
+      try {
+        parser.push(chunk);
+        while (values.length < commands.length) {
+          const parsed = parser.tryParse();
+          if (!parsed) break;
+          parser.consume(parsed.consumed);
+          values.push(parsed.value);
+        }
+        if (values.length === commands.length) {
+          finish(values);
+        }
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)));
+      }
+    };
+    const onError = (error: Error) => fail(error);
+    const onClose = () => {
+      if (values.length < commands.length) {
+        fail(new Error("Redis connection closed before full response was received"));
+      }
+    };
+    const timer = setTimeout(() => {
+      fail(new Error(`Redis command timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    socket.on("data", onData);
+    socket.once("error", onError);
+    socket.once("close", onClose);
+    for (const command of commands) {
+      socket.write(encodeCommand(command));
+    }
+  });
+}
+
+export async function redisPing(): Promise<void> {
+  await runSequence([["PING"]]);
+}
+
+export async function redisGet(key: string): Promise<string | null> {
+  const values = await runSequence([["GET", key]]);
+  const value = values.at(-1);
+  return typeof value === "string" ? value : null;
+}
+
+export async function redisSetEx(key: string, value: string, ttlSeconds: number): Promise<void> {
+  await runSequence([["SET", key, value, "EX", String(ttlSeconds)]]);
+}
+
+export async function redisDel(key: string): Promise<void> {
+  await runSequence([["DEL", key]]);
+}
+
+export async function redisSetNxPx(key: string, value: string, ttlMs: number): Promise<boolean> {
+  const values = await runSequence([["SET", key, value, "NX", "PX", String(ttlMs)]]);
+  return values.at(-1) === "OK";
+}
+
+// refresh ロック解放時に他 worker のロックを消さないよう compare-and-delete する。
+export async function redisCompareAndDelete(key: string, expectedValue: string): Promise<boolean> {
+  const values = await runSequence([
+    [
+      "EVAL",
+      "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end",
+      "1",
+      key,
+      expectedValue,
+    ],
+  ]);
+  return values.at(-1) === 1;
+}

--- a/app/services/redis.server.ts
+++ b/app/services/redis.server.ts
@@ -32,6 +32,10 @@ type SocketWithConnectPhaseError = (Socket | TLSSocket) & {
   [SOCKET_CONNECT_PHASE_ERROR]?: Error;
 };
 
+function getSocketConnectPhaseError(socket: Socket | TLSSocket): Error | undefined {
+  return (socket as SocketWithConnectPhaseError)[SOCKET_CONNECT_PHASE_ERROR];
+}
+
 // Redis の RESP 応答を逐次パースし、ソケットの chunk 分割を吸収する。
 class RespParser {
   private buffer = Buffer.alloc(0);
@@ -268,7 +272,7 @@ async function runSequence(sequence: string[][]): Promise<RespValue[]> {
   commands.push(...sequence);
 
   const socket = await openSocket(endpoint, timeoutMs);
-  const connectPhaseError = (socket as SocketWithConnectPhaseError)[SOCKET_CONNECT_PHASE_ERROR];
+  const connectPhaseError = getSocketConnectPhaseError(socket);
   if (connectPhaseError) {
     throw connectPhaseError;
   }
@@ -320,7 +324,8 @@ async function runSequence(sequence: string[][]): Promise<RespValue[]> {
     const onError = (error: Error) => fail(error);
     const onClose = () => {
       if (values.length < commands.length) {
-        fail(new Error("Redis connection closed before full response was received"));
+        const closeCause = getSocketConnectPhaseError(socket);
+        fail(closeCause ?? new Error("Redis connection closed before full response was received"));
       }
     };
     const timer = setTimeout(() => {

--- a/app/services/redis.server.ts
+++ b/app/services/redis.server.ts
@@ -151,7 +151,14 @@ function getRedisEndpoint(): RedisEndpoint | null {
 
   return {
     host: url.hostname || "127.0.0.1",
-    port: url.port ? Number.parseInt(url.port, 10) : 6379,
+    port: (() => {
+      if (!url.port) return 6379;
+      const parsedPort = Number.parseInt(url.port, 10);
+      if (!Number.isFinite(parsedPort) || !Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65535) {
+        throw new Error("REDIS_URL port is invalid. Use an integer between 1 and 65535.");
+      }
+      return parsedPort;
+    })(),
     db,
     username: url.username ? decodeURIComponent(url.username) : null,
     password: url.password ? decodeURIComponent(url.password) : null,

--- a/app/services/redis.server.ts
+++ b/app/services/redis.server.ts
@@ -27,6 +27,10 @@ type RedisEndpoint = {
 
 // 今回使う RESP の最小表現。bulk string / integer / array だけ扱えれば必要コマンドを解釈できる。
 type RespValue = string | null | number | RespValue[];
+const SOCKET_CONNECT_PHASE_ERROR = Symbol("socket-connect-phase-error");
+type SocketWithConnectPhaseError = (Socket | TLSSocket) & {
+  [SOCKET_CONNECT_PHASE_ERROR]?: Error;
+};
 
 // Redis の RESP 応答を逐次パースし、ソケットの chunk 分割を吸収する。
 class RespParser {
@@ -160,8 +164,8 @@ function getRedisEndpoint(): RedisEndpoint | null {
       return parsedPort;
     })(),
     db,
-    username: url.username ? decodeURIComponent(url.username) : null,
-    password: url.password ? decodeURIComponent(url.password) : null,
+    username: url.username || null,
+    password: url.password || null,
     tls: url.protocol === "rediss:",
   };
 }
@@ -200,10 +204,17 @@ function openSocket(endpoint: RedisEndpoint, timeoutMs: number): Promise<Socket 
       callback();
     };
     const onError = (error: Error) => {
-      settle(() => {
-        socket.destroy();
-        reject(error);
-      });
+      if (!settled) {
+        settle(() => {
+          socket.destroy();
+          reject(error);
+        });
+        return;
+      }
+      // connect 完了直後に飛ぶ error は runSequence 側へ即伝搬できるよう保持する。
+      const socketWithError = socket as SocketWithConnectPhaseError;
+      socketWithError[SOCKET_CONNECT_PHASE_ERROR] = error;
+      socket.destroy();
     };
     const onConnect = () => {
       settle(() => {
@@ -254,6 +265,10 @@ async function runSequence(sequence: string[][]): Promise<RespValue[]> {
   commands.push(...sequence);
 
   const socket = await openSocket(endpoint, timeoutMs);
+  const connectPhaseError = (socket as SocketWithConnectPhaseError)[SOCKET_CONNECT_PHASE_ERROR];
+  if (connectPhaseError) {
+    throw connectPhaseError;
+  }
   const parser = new RespParser();
   const values: RespValue[] = [];
 

--- a/app/services/session-secret.server.ts
+++ b/app/services/session-secret.server.ts
@@ -10,6 +10,8 @@
  * - developmentでは未設定時に固定の開発用シークレットを使い、警告を出す。
  * - `resolvedSessionSecret` をexportし、Cookie `secrets` に共通利用させる。
  */
+import { logger } from "./logger.server";
+
 const sessionSecret = process.env.SESSION_SECRET ?? "";
 export const isProduction = process.env.NODE_ENV === "production";
 const defaultDevSessionSecret =
@@ -24,7 +26,7 @@ if (!resolvedSessionSecret) {
 }
 
 if (usingDefaultDevSessionSecret) {
-  console.warn(
+  logger.warn(
     "SESSION_SECRET が未設定のため、固定の開発用シークレットを使用しています。ローカルの安定運用のため、.env に SESSION_SECRET を明示設定してください。",
   );
 }


### PR DESCRIPTION
# Summary

OneDrive OAuth のサーバー側セッション管理を Redis ベースへ移行し、Redis 障害時の挙動を fail-closed に統一しました。あわせて、OAuth 開始・callback・セッション参照・保存系 API で Redis 障害を認証切れと混同せず `503` として返すようにし、refresh の多重実行防止、Redis timeout 時の cleanup、運用ログの整備まで含めて回帰テストを追加しています。

# Background

- OneDrive OAuth の token/session 情報をプロセスメモリで保持しており、再起動・再デプロイ・複数インスタンスで認証継続性が担保できていませんでした。
- Redis 障害時の挙動が未定義で、認証切れと基盤障害を誤分類する余地がありました。
- callback 時に Redis 障害があっても token exchange まで進んでしまうため、部分成功を避ける fail-closed 要件を満たしていませんでした。
- 障害ログが `console` に散っていたため、ESLint warning と運用上の一貫性の両面で整理が必要でした。

# Changes

## 1. Redis ベースの OAuth セッションストアを追加

- `app/services/redis.server.ts`
  - 依存追加なしの最小 Redis クライアントを追加
  - `SET/GET/DEL/SET NX PX/EVAL` を実装
  - connect timeout / command timeout 時に `socket.destroy()` で cleanup
- `app/services/onedrive-oauth-session.server.ts`
  - `sessionId -> { accessToken, refreshToken, expiresAt }` を Redis に保存
  - refresh lock / failure 共有 / wait を Redis ベースで実装
  - Redis 障害を `OAuthSessionStoreUnavailableError` に正規化
  - session store preflight を `PING` ではなく write/read/delete probe に強化

## 2. OneDrive OAuth を fail-closed に変更

- `app/services/onedrive-auth.server.ts`
  - メモリ token store を廃止し、Redis ストア経由に変更
  - request 経路では Redis-backed session のみ利用し、env token fallback を禁止
  - refresh を Redis lock で single-flight 化
  - leader refresh failure を follower へ共有
- `app/routes/auth.onedrive.login.tsx`
  - Redis preflight 失敗時は `503`
  - Redis 障害ログを出力
- `app/routes/auth.onedrive.callback.tsx`
  - token exchange 前に Redis preflight を実施
  - Redis 障害時は token exchange / token persist 前に `503` で停止

## 3. 保存系・参照系 API の Redis 障害を `503` に統一

- `app/routes/api.onedrive.session-status.tsx`
- `app/routes/api.onedrive.upload.tsx`
- `app/routes/api.onedrive.archive.tsx`
- `app/routes/api.onedrive.evidence-image.tsx`

上記で `OAuthSessionStoreUnavailableError` を受けた場合に、認証切れではなく「OneDrive 認証基盤の一時障害」として `503` を返すようにしました。

## 4. ログ出力の入口を統一

- `app/services/logger.server.ts` を追加
- server route/service の `console.error` / `console.warn` を `logger.error` / `logger.warn` に置換
- `no-console` warning を解消

## 5. ドキュメント更新

- `REQUIREMENTS.md`
  - Redis 必須、HTTPS 必須、Redis 障害時の `503` / fail-closed を明記
- `README.md`
  - Redis 必須化と実行前提を反映
- `.env.example`
  - `REDIS_URL` など必要な環境変数を追加

# Test

実行コマンド:

```bash
npm run lint
npm run typecheck
npm test
npm run build
```

結果:

- `lint`: green, warning 0
- `typecheck`: green
- `test`: 182 tests green
- `build`: green

補足:

- `npm test` を `typecheck` と並列に回すと `.react-router/types` 生成競合で `ENOENT` が出ることがあるため、最終確認は順次実行で green を確認しています。

# Main Files

- `app/services/redis.server.ts`
- `app/services/onedrive-oauth-session.server.ts`
- `app/services/onedrive-auth.server.ts`
- `app/routes/auth.onedrive.login.tsx`
- `app/routes/auth.onedrive.callback.tsx`
- `app/routes/api.onedrive.session-status.tsx`
- `app/routes/api.onedrive.upload.tsx`
- `app/routes/api.onedrive.archive.tsx`
- `app/routes/api.onedrive.evidence-image.tsx`
- `app/services/logger.server.ts`

# Risks / Notes

- Redis クライアントは command ごとに short-lived connection を張る最小実装です。現時点の想定規模では許容しますが、高負荷時は connection reuse / pooling を別 PR で検討余地があります。
- `redis://` と `rediss://` の両方を許容しています。本番では `rediss://` または信頼できる内部ネットワーク前提です。
- Vite build には既存の dynamic import 警告が残りますが、本 PR 起因の blocking issue ではありません。

# Review Points

- Redis 障害時に login / callback / session-status / upload / archive / evidence-image が期待どおり `503` になるか
- callback が Redis preflight 失敗時に token exchange 前で停止するか
- refresh single-flight が複数インスタンス前提でも破綻しないか
- logger 置換で診断に必要な情報が落ちていないか
