### PR TITLE
Issue41 compose dev env

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -134,6 +134,10 @@
    - CSRF 対策は署名付き Secure Cookie を用いた方式を維持してよく、Redis 保存は必須としない。
    - OneDrive OAuth を利用するすべての外部公開経路は HTTPS を必須とし、HTTP では認証フローを開始・完了させない。
    - `SESSION_SECRET` は production で必須とし、Cookie 署名の信頼境界を維持する。
+   - Redis に保存する OneDrive OAuth の `accessToken` / `refreshToken` を平文で保存してはならない。保存時はサーバー側で暗号化し、読み取り時に復号して利用する。
+   - Redis 上の token 保存形式はバージョン識別子を先頭に含むこと（例: `v1.<iv>.<authTag>.<ciphertext>`）。未対応バージョンや不正形式は fail-closed で無効セッションとして扱う。
+   - token 暗号化鍵は `SESSION_SECRET` から導出し、プロセス再起動後も同一 `SESSION_SECRET` で復号可能であること。
+   - `SESSION_SECRET` が変更された場合、既存の暗号化済み OAuth セッションは復号不能となるため無効化され、再認証を要求する挙動を許容する。
    - Redis は OneDrive OAuth のサーバー側セッションストアとして必須とする。Redis が利用不能な場合、OAuth フローは fail-closed で停止し、メモリストア等への自動 fallback は行わない。
    - Redis 接続障害、timeout、読み書き失敗時は、OAuth 開始、callback、セッション参照、access token refresh を `503 Service Unavailable` として扱う。
    - Redis 障害時は、ユーザーに認証切れや再認証要求として見せてはならない。UI には「一時的なシステム障害」の種別で表示し、認証エラーと明確に区別する。

--- a/app/routes/api.onedrive.archive.test.ts
+++ b/app/routes/api.onedrive.archive.test.ts
@@ -31,6 +31,11 @@ vi.mock("../services/csrf.server", () => ({
   verifyCsrfToken: vi.fn(),
 }));
 
+vi.mock("../services/onedrive-auth.server", () => ({
+  isOneDriveOAuthTokenMissingError: (error: unknown) =>
+    error instanceof Error && error.name === "OneDriveOAuthTokenMissingError",
+}));
+
 type MockGitHubService = {
   getPullRequest: ReturnType<typeof vi.fn>;
 };

--- a/app/routes/api.onedrive.archive.tsx
+++ b/app/routes/api.onedrive.archive.tsx
@@ -12,6 +12,7 @@ import { createGitHubServiceFromEnv, type PullRequestRef } from "../services/git
 import { logger } from "../services/logger.server";
 import { createOneDriveServiceFromEnv } from "../services/onedrive.server";
 import { isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
+import { isOneDriveOAuthTokenMissingError } from "../services/onedrive-auth.server";
 import { validatePrRefInput } from "../services/validation";
 import { verifyCsrfToken } from "../services/csrf.server";
 import { isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
@@ -436,7 +437,7 @@ export async function action({ request }: ActionFunctionArgs) {
         { status: 502 },
       );
     }
-    const isAuthLike = isOneDriveAuthLikeError(rawMessage);
+    const isAuthLike = isOneDriveOAuthTokenMissingError(error) || isOneDriveAuthLikeError(rawMessage);
     const message = isAuthLike
       ? "OneDrive 認証が切れています。再認証してから再実行してください。"
       : "OneDrive 上の archive.json 取得に失敗しました。しばらくしてから再実行してください。";

--- a/app/routes/api.onedrive.evidence-image.test.ts
+++ b/app/routes/api.onedrive.evidence-image.test.ts
@@ -40,6 +40,11 @@ vi.mock("../services/onedrive.server", () => ({
   },
 }));
 
+vi.mock("../services/onedrive-auth.server", () => ({
+  isOneDriveOAuthTokenMissingError: (error: unknown) =>
+    error instanceof Error && error.name === "OneDriveOAuthTokenMissingError",
+}));
+
 type MockOneDriveService = {
   getBinary: ReturnType<typeof vi.fn>;
 };

--- a/app/routes/api.onedrive.evidence-image.tsx
+++ b/app/routes/api.onedrive.evidence-image.tsx
@@ -11,6 +11,7 @@ import type { LoaderFunctionArgs } from "react-router";
 import { logger } from "../services/logger.server";
 import { createOneDriveServiceFromEnv, OneDriveApiError } from "../services/onedrive.server";
 import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
+import { isOneDriveOAuthTokenMissingError } from "../services/onedrive-auth.server";
 import { isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import {
   isEvidenceImageTokenFormat,
@@ -139,7 +140,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     }
 
     const rawMessage = error instanceof Error ? error.message : String(error);
-    const isAuthLike = isOneDriveAuthLikeError(rawMessage);
+    const isAuthLike = isOneDriveOAuthTokenMissingError(error) || isOneDriveAuthLikeError(rawMessage);
     if (isAuthLike) {
       const parsed = extractOneDriveError(rawMessage);
       const status = parsed.code === "accessDenied" ? 403 : 401;

--- a/app/routes/api.onedrive.session-status.test.ts
+++ b/app/routes/api.onedrive.session-status.test.ts
@@ -1,11 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { loader } from "./api.onedrive.session-status";
-import { getAccessToken } from "../services/onedrive-auth.server";
+import { getAccessToken, OneDriveOAuthTokenMissingError } from "../services/onedrive-auth.server";
 import { createOneDriveService } from "../services/onedrive.server";
 import { OAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 
 vi.mock("../services/onedrive-auth.server", () => ({
+  OneDriveOAuthTokenMissingError: class OneDriveOAuthTokenMissingError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "OneDriveOAuthTokenMissingError";
+    }
+  },
   getAccessToken: vi.fn(),
+  isOneDriveOAuthTokenMissingError: (error: unknown) =>
+    error instanceof Error && error.name === "OneDriveOAuthTokenMissingError",
 }));
 
 vi.mock("../services/onedrive.server", () => ({
@@ -80,9 +88,7 @@ describe("api.onedrive.session-status loader", () => {
   });
 
   it("token欠落は認証エラーとして401を返す", async () => {
-    vi.mocked(getAccessToken).mockRejectedValue(
-      new Error("OneDrive OAuth token がありません。/auth/onedrive/login で認証してください。"),
-    );
+    vi.mocked(getAccessToken).mockRejectedValue(new OneDriveOAuthTokenMissingError("token missing"));
 
     const response = await loader({ request: buildRequest() } as never);
     const body = (await response.json()) as {

--- a/app/routes/api.onedrive.session-status.test.ts
+++ b/app/routes/api.onedrive.session-status.test.ts
@@ -78,4 +78,39 @@ describe("api.onedrive.session-status loader", () => {
     expect(errorSpy).toHaveBeenCalled();
     errorSpy.mockRestore();
   });
+
+  it("token欠落は認証エラーとして401を返す", async () => {
+    vi.mocked(getAccessToken).mockRejectedValue(
+      new Error("OneDrive OAuth token がありません。/auth/onedrive/login で認証してください。"),
+    );
+
+    const response = await loader({ request: buildRequest() } as never);
+    const body = (await response.json()) as {
+      ok: false;
+      isAuthError: boolean;
+      error: string;
+    };
+
+    expect(response.status).toBe(401);
+    expect(body.ok).toBe(false);
+    expect(body.isAuthError).toBe(true);
+  });
+
+  it("token crypto 障害は認証エラー扱いせず502を返す", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(getAccessToken).mockRejectedValue(new Error("OneDrive token crypto encrypt failed: cipher failed"));
+
+    const response = await loader({ request: buildRequest() } as never);
+    const body = (await response.json()) as {
+      ok: false;
+      isAuthError: boolean;
+      error: string;
+    };
+
+    expect(response.status).toBe(502);
+    expect(body.ok).toBe(false);
+    expect(body.isAuthError).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
 });

--- a/app/routes/api.onedrive.session-status.tsx
+++ b/app/routes/api.onedrive.session-status.tsx
@@ -11,7 +11,7 @@
 import type { LoaderFunctionArgs } from "react-router";
 import { logger } from "../services/logger.server";
 import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
-import { getAccessToken } from "../services/onedrive-auth.server";
+import { getAccessToken, isOneDriveOAuthTokenMissingError } from "../services/onedrive-auth.server";
 import { isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import { createOneDriveService } from "../services/onedrive.server";
 
@@ -62,7 +62,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     }
     const rawMessage = error instanceof Error ? error.message : "Unknown error";
     const parsed = extractOneDriveError(rawMessage);
-    const isAuthLike = isOneDriveAuthLikeError(rawMessage);
+    const isAuthLike = isOneDriveOAuthTokenMissingError(error) || isOneDriveAuthLikeError(rawMessage);
 
     const hasDetail = Boolean(parsed.code || parsed.message);
     const message = isAuthLike

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -59,6 +59,11 @@ vi.mock("../services/evidence-images.server", () => ({
   buildImageBaseName: vi.fn(),
 }));
 
+vi.mock("../services/onedrive-auth.server", () => ({
+  isOneDriveOAuthTokenMissingError: (error: unknown) =>
+    error instanceof Error && error.name === "OneDriveOAuthTokenMissingError",
+}));
+
 type MockGitHubService = {
   getPullRequest: ReturnType<typeof vi.fn>;
   getPullRequestReviews: ReturnType<typeof vi.fn>;

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -15,6 +15,7 @@ import {
 import { getHttpStatus } from "../services/http-status";
 import { logger } from "../services/logger.server";
 import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
+import { isOneDriveOAuthTokenMissingError } from "../services/onedrive-auth.server";
 import { isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import { createOneDriveServiceFromEnv, OneDriveApiError } from "../services/onedrive.server";
 // 画像保存ユーティリティ
@@ -439,7 +440,8 @@ export async function action({ request }: ActionFunctionArgs) {
     }
 
     const parsed = extractOneDriveError(rawMessage);
-    const isAuthLike = isOneDriveAuthLikeError(rawMessage); // エラーメッセージの解析結果が認証エラーっぽいかどうか。これが true の場合は 401、そうでない場合は 502 として返す。
+    const isAuthLike =
+      isOneDriveOAuthTokenMissingError(error) || isOneDriveAuthLikeError(rawMessage); // エラーメッセージ依存だけにせず、専用エラー型も認証エラーとして扱う。
     if (error instanceof ArchiveJsonInvalidError) {
       return Response.json(
         {
@@ -649,7 +651,7 @@ async function saveEvidenceImages({
       const rawMessage = error instanceof Error ? error.message : String(error);
       // OneDrive への保存に失敗した場合、認証エラーっぽいかどうかに関わらず、まずはエラーメッセージを解析してみる。
       // これにより、OneDrive API のエラーレスポンスの形式が変わったり、予期しないエラーが発生した場合でも、ユーザーには再認証が必要な可能性があることを伝えることができる。
-      if (isOneDriveAuthLikeError(rawMessage)) {
+      if (isOneDriveOAuthTokenMissingError(error) || isOneDriveAuthLikeError(rawMessage)) {
         const savedPaths = results
           .filter((record) => record.status === "success" && record.onedrivePath)
           .map((record) => record.onedrivePath as string);

--- a/app/routes/auth.onedrive.callback.test.ts
+++ b/app/routes/auth.onedrive.callback.test.ts
@@ -41,9 +41,17 @@ vi.mock("../services/onedrive-oauth-session.server", () => ({
       this.name = "OAuthSessionStoreUnavailableError";
     }
   },
+  OAuthSessionTokenCryptoError: class OAuthSessionTokenCryptoError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "OAuthSessionTokenCryptoError";
+    }
+  },
   ensureOAuthSessionStoreAvailable: vi.fn(async () => {}),
   isOAuthSessionStoreUnavailableError: (error: unknown) =>
     error instanceof Error && error.name === "OAuthSessionStoreUnavailableError",
+  isOAuthSessionTokenCryptoError: (error: unknown) =>
+    error instanceof Error && error.name === "OAuthSessionTokenCryptoError",
 }));
 
 describe("auth.onedrive.callback loader", () => {
@@ -155,6 +163,40 @@ describe("auth.onedrive.callback loader", () => {
         constructor() {
           super("redis down on persist");
           this.name = "OAuthSessionStoreUnavailableError";
+        }
+      })(),
+    );
+
+    const request = new Request(
+      "https://localhost:5173/auth/onedrive/callback?code=test-code&state=bind-a.nonce-1",
+      { headers: { Cookie: "onedrive_oauth_state=stub; onedrive_oauth_bind=stub" } },
+    );
+
+    const response = await loader({ request });
+    const body = await response.text();
+
+    expect(response.status).toBe(503);
+    expect(body).toContain("Connect OneDrive から認証をやり直してください");
+    expect(exchangeCodeForToken).toHaveBeenCalledTimes(1);
+    expect(persistTokenForSession).toHaveBeenCalledTimes(1);
+    expect(onedriveOAuthStateCookie.serialize).toHaveBeenCalledWith("", { maxAge: 0 });
+    expect(onedriveOAuthBindCookie.serialize).toHaveBeenCalledWith("", { maxAge: 0 });
+  });
+
+  it("token暗号化失敗時も再認証案内の503を返し、state/bind cookie をクリアする", async () => {
+    vi.mocked(ensureOAuthSessionStoreAvailable).mockResolvedValue(undefined);
+    vi.mocked(onedriveOAuthStateCookie.parse).mockResolvedValue("bind-a.nonce-1");
+    vi.mocked(onedriveOAuthBindCookie.parse).mockResolvedValue("bind-a");
+    vi.mocked(exchangeCodeForToken).mockResolvedValue({
+      accessToken: "access-token-1",
+      refreshToken: "refresh-token-1",
+      expiresAt: Date.now() + 60_000,
+    });
+    vi.mocked(persistTokenForSession).mockRejectedValue(
+      new (class OAuthSessionTokenCryptoError extends Error {
+        constructor() {
+          super("OneDrive token crypto encrypt failed: cipher failed");
+          this.name = "OAuthSessionTokenCryptoError";
         }
       })(),
     );

--- a/app/routes/auth.onedrive.callback.tsx
+++ b/app/routes/auth.onedrive.callback.tsx
@@ -134,9 +134,18 @@ export async function loader({ request }: { request: Request }) {
   try {
     await persistTokenForSession(sessionId, tokenCache);
   } catch (error) {
-    if (isOAuthSessionStoreUnavailableError(error) || isOAuthSessionTokenCryptoError(error)) {
+    // トークン保存失敗の原因がセッションストア障害なのかを判別し、適切なレスポンスを返す。
+    if (isOAuthSessionStoreUnavailableError(error)) {
       logger.error("OneDrive OAuth session store failed.", {
         message: error.message,
+        errorType: "store-unavailable",
+      });
+      return buildOAuthInfrastructureErrorResponse(OAUTH_PERSIST_FAILED_AFTER_EXCHANGE_MESSAGE);
+    }
+    if (isOAuthSessionTokenCryptoError(error)) {
+      logger.error("OneDrive OAuth token crypto failed.", {
+        message: error.message,
+        errorType: "token-crypto",
       });
       return buildOAuthInfrastructureErrorResponse(OAUTH_PERSIST_FAILED_AFTER_EXCHANGE_MESSAGE);
     }

--- a/app/routes/auth.onedrive.callback.tsx
+++ b/app/routes/auth.onedrive.callback.tsx
@@ -9,6 +9,7 @@ import { isHttpsRequest } from "../services/https-validation.server";
 import { logger } from "../services/logger.server";
 import {
   ensureOAuthSessionStoreAvailable,
+  isOAuthSessionTokenCryptoError,
   isOAuthSessionStoreUnavailableError,
 } from "../services/onedrive-oauth-session.server";
 import {
@@ -133,7 +134,7 @@ export async function loader({ request }: { request: Request }) {
   try {
     await persistTokenForSession(sessionId, tokenCache);
   } catch (error) {
-    if (isOAuthSessionStoreUnavailableError(error)) {
+    if (isOAuthSessionStoreUnavailableError(error) || isOAuthSessionTokenCryptoError(error)) {
       logger.error("OneDrive OAuth session store failed.", {
         message: error.message,
       });

--- a/app/services/onedrive-auth.server.test.ts
+++ b/app/services/onedrive-auth.server.test.ts
@@ -64,6 +64,8 @@ vi.mock("./onedrive-oauth-session.server", () => ({
 
 import {
   getAccessToken,
+  isOneDriveOAuthTokenMissingError,
+  OneDriveOAuthTokenMissingError,
   onedriveOAuthSessionCookie,
   persistTokenForSession,
 } from "./onedrive-auth.server";
@@ -247,5 +249,18 @@ describe("onedrive-auth refresh single-flight", () => {
 
     await expect(getAccessToken(request)).rejects.toThrow(/timed out after \d+ms/);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("session token が存在しない場合は専用エラーを返す", async () => {
+    vi.spyOn(onedriveOAuthSessionCookie, "parse").mockResolvedValue("session-missing-token" as never);
+    const request = {
+      headers: { get: (name: string) => (name.toLowerCase() === "cookie" ? "onedrive_oauth_session=stub" : null) },
+    } as Request;
+
+    await expect(getAccessToken(request)).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(OneDriveOAuthTokenMissingError);
+      expect(isOneDriveOAuthTokenMissingError(error)).toBe(true);
+      return true;
+    });
   });
 });

--- a/app/services/onedrive-auth.server.test.ts
+++ b/app/services/onedrive-auth.server.test.ts
@@ -25,6 +25,13 @@ const { mockStoreRefreshFailure } = vi.hoisted(() => ({
     mockRefreshFailures.set(sessionId, message);
   }),
 }));
+const { mockStoreTokenForSession } = vi.hoisted(() => ({
+  mockStoreTokenForSession: vi.fn(
+    async (sessionId: string, cache: { accessToken: string; refreshToken: string | null; expiresAt: number }) => {
+      mockSessionStore.set(sessionId, cache);
+    },
+  ),
+}));
 const { mockWaitForRefreshOutcome } = vi.hoisted(() => ({
   mockWaitForRefreshOutcome: vi.fn(async (sessionId: string) => {
     for (let attempt = 0; attempt < 30; attempt++) {
@@ -43,12 +50,18 @@ const { mockWaitForRefreshOutcome } = vi.hoisted(() => ({
 }));
 
 vi.mock("./onedrive-oauth-session.server", () => ({
+  OAuthSessionTokenCryptoError: class OAuthSessionTokenCryptoError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "OAuthSessionTokenCryptoError";
+    }
+  },
+  isOAuthSessionTokenCryptoError: (error: unknown) =>
+    error instanceof Error && error.name === "OAuthSessionTokenCryptoError",
   OAuthSessionStoreUnavailableError: class OAuthSessionStoreUnavailableError extends Error {},
   isOAuthSessionStoreUnavailableError: (error: unknown) => error instanceof Error && error.name === "OAuthSessionStoreUnavailableError",
   ensureOAuthSessionStoreAvailable: vi.fn(async () => {}),
-  storeTokenForSession: vi.fn(async (sessionId: string, cache: { accessToken: string; refreshToken: string | null; expiresAt: number }) => {
-    mockSessionStore.set(sessionId, cache);
-  }),
+  storeTokenForSession: mockStoreTokenForSession,
   getTokenForSession: vi.fn(async (sessionId: string | null) => (sessionId ? mockSessionStore.get(sessionId) ?? null : null)),
   deleteTokenForSession: vi.fn(async (sessionId: string) => {
     mockSessionStore.delete(sessionId);
@@ -84,6 +97,7 @@ describe("onedrive-auth refresh single-flight", () => {
     mockRefreshFailures.clear();
     mockTryAcquireRefreshLock.mockClear();
     mockReleaseRefreshLock.mockClear();
+    mockStoreTokenForSession.mockClear();
     mockStoreRefreshFailure.mockClear();
     mockWaitForRefreshOutcome.mockClear();
     delete process.env.REDIS_URL;
@@ -248,6 +262,41 @@ describe("onedrive-auth refresh single-flight", () => {
     mockStoreRefreshFailure.mockRejectedValueOnce(new Error("redis write timed out"));
 
     await expect(getAccessToken(request)).rejects.toThrow(/timed out after \d+ms/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("token暗号化失敗は refresh failure に保存しない", async () => {
+    const sessionId = `session-${crypto.randomUUID()}`;
+    await persistTokenForSession(sessionId, {
+      accessToken: "expired-access",
+      refreshToken: "refresh-token-1",
+      expiresAt: Date.now() - 1000,
+    });
+    vi.spyOn(onedriveOAuthSessionCookie, "parse").mockResolvedValue(sessionId as never);
+    const request = {
+      headers: { get: (name: string) => (name.toLowerCase() === "cookie" ? "onedrive_oauth_session=stub" : null) },
+    } as Request;
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "new-access-token",
+          refresh_token: "refresh-token-2",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    mockStoreTokenForSession.mockRejectedValueOnce(
+      Object.assign(new Error("OneDrive token crypto encrypt failed: cipher failed"), {
+        name: "OAuthSessionTokenCryptoError",
+      }),
+    );
+
+    await expect(getAccessToken(request)).rejects.toThrow("OneDrive token crypto encrypt failed: cipher failed");
+    expect(mockStoreRefreshFailure).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/app/services/onedrive-auth.server.ts
+++ b/app/services/onedrive-auth.server.ts
@@ -58,6 +58,18 @@ type TokenResponse = {
   scope?: string;
 };
 
+// OAuth セッションに token が存在しないことを示す専用エラー。
+export class OneDriveOAuthTokenMissingError extends Error {
+  constructor(message = "OneDrive OAuth token is missing.") {
+    super(message);
+    this.name = "OneDriveOAuthTokenMissingError";
+  }
+}
+
+export function isOneDriveOAuthTokenMissingError(error: unknown): error is OneDriveOAuthTokenMissingError {
+  return error instanceof OneDriveOAuthTokenMissingError;
+}
+
 function isOneDriveOAuthConfigured(): boolean {
   return Boolean(process.env.ONEDRIVE_CLIENT_ID && process.env.ONEDRIVE_CLIENT_SECRET && process.env.ONEDRIVE_REDIRECT_URI);
 }
@@ -290,7 +302,7 @@ export async function getAccessToken(request?: Request): Promise<string> {
       return refreshed.accessToken;
     }
 
-    throw new Error("OneDrive OAuth token がありません。/auth/onedrive/login で認証してください。");
+    throw new OneDriveOAuthTokenMissingError("OneDrive OAuth token is missing. Please re-authenticate.");
   }
 
   throw new Error(

--- a/app/services/onedrive-auth.server.ts
+++ b/app/services/onedrive-auth.server.ts
@@ -11,6 +11,7 @@ import { createCookie } from "react-router";
 import {
   clearRefreshFailure,
   getTokenForSession,
+  isOAuthSessionTokenCryptoError,
   OAuthSessionStoreUnavailableError,
   releaseRefreshLock,
   storeTokenForSession,
@@ -249,7 +250,7 @@ async function refreshAccessTokenForSession(sessionId: string, refreshToken: str
       await persistTokenForSession(sessionId, refreshed);
       return refreshed;
     } catch (error) {
-      if (!(error instanceof OAuthSessionStoreUnavailableError)) {
+      if (!(error instanceof OAuthSessionStoreUnavailableError) && !isOAuthSessionTokenCryptoError(error)) {
         const message = error instanceof Error ? error.message : String(error);
         try {
           await storeRefreshFailure(sessionId, message, REFRESH_FAILURE_TTL_SECONDS);

--- a/app/services/onedrive-errors.server.test.ts
+++ b/app/services/onedrive-errors.server.test.ts
@@ -22,8 +22,8 @@ describe("onedrive-errors", () => {
     });
   });
 
-  it("isOneDriveAuthLikeError は token欠落メッセージを認証エラーとして扱う", () => {
-    const raw = "OneDrive OAuth token がありません。/auth/onedrive/login で認証してください。";
+  it("isOneDriveAuthLikeError は 401 エラー文言を認証エラーとして扱う", () => {
+    const raw = "OneDrive API error (401) [code=InvalidAuthenticationToken]: token expired";
     expect(isOneDriveAuthLikeError(raw)).toBe(true);
   });
 

--- a/app/services/onedrive-errors.server.test.ts
+++ b/app/services/onedrive-errors.server.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractOneDriveError } from "./onedrive-errors.server";
+import { extractOneDriveError, isOneDriveAuthLikeError } from "./onedrive-errors.server";
 
 describe("onedrive-errors", () => {
   it("extractOneDriveError は message 末尾の request-id メタを除去する", () => {
@@ -20,5 +20,15 @@ describe("onedrive-errors", () => {
       code: "generalException",
       message: "transient backend error",
     });
+  });
+
+  it("isOneDriveAuthLikeError は token欠落メッセージを認証エラーとして扱う", () => {
+    const raw = "OneDrive OAuth token がありません。/auth/onedrive/login で認証してください。";
+    expect(isOneDriveAuthLikeError(raw)).toBe(true);
+  });
+
+  it("isOneDriveAuthLikeError は token crypto エラーを認証エラー扱いしない", () => {
+    const raw = "OneDrive token crypto encrypt failed: cipher failed";
+    expect(isOneDriveAuthLikeError(raw)).toBe(false);
   });
 });

--- a/app/services/onedrive-errors.server.ts
+++ b/app/services/onedrive-errors.server.ts
@@ -25,7 +25,7 @@ export function extractOneDriveError(rawMessage: string): { code?: string; messa
 export function isOneDriveAuthLikeError(rawMessage: string): boolean {
   const message = rawMessage.toLowerCase();
   return (
-    message.includes("onedrive oauth token") ||
+    message.includes("onedrive oauth token がありません") ||
     message.includes("onedrive oauth error") ||
     message.includes("onedrive api error (401)") ||
     message.includes("onedrive api error (403)") ||

--- a/app/services/onedrive-errors.server.ts
+++ b/app/services/onedrive-errors.server.ts
@@ -25,7 +25,6 @@ export function extractOneDriveError(rawMessage: string): { code?: string; messa
 export function isOneDriveAuthLikeError(rawMessage: string): boolean {
   const message = rawMessage.toLowerCase();
   return (
-    message.includes("onedrive oauth token がありません") ||
     message.includes("onedrive oauth error") ||
     message.includes("onedrive api error (401)") ||
     message.includes("onedrive api error (403)") ||

--- a/app/services/onedrive-oauth-session.server.test.ts
+++ b/app/services/onedrive-oauth-session.server.test.ts
@@ -28,6 +28,10 @@ const { redisMockState } = vi.hoisted(() => ({
   },
 }));
 
+const { mockLoggerWarn } = vi.hoisted(() => ({
+  mockLoggerWarn: vi.fn(),
+}));
+
 vi.mock("./redis.server", () => ({
   redisCompareAndDelete: vi.fn(),
   redisDel: vi.fn(async (key: string) => {
@@ -82,10 +86,20 @@ vi.mock("./redis.server", () => ({
   }),
 }));
 
+vi.mock("./logger.server", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: mockLoggerWarn,
+    error: vi.fn(),
+  },
+}));
+
 import {
+  isOAuthSessionTokenCryptoError,
   ensureOAuthSessionStoreAvailable,
   getTokenForSession,
   isOAuthSessionStoreUnavailableError,
+  OAuthSessionTokenCryptoError,
   storeTokenForSession,
   waitForRefreshOutcome,
 } from "./onedrive-oauth-session.server";
@@ -105,6 +119,7 @@ describe("onedrive-oauth-session", () => {
     redisMockState.sessionDeleteError = null;
     redisMockState.deletedSessionKeys.length = 0;
     redisMockState.redisGetCallCount = 0;
+    mockLoggerWarn.mockReset();
   });
 
   it("session store preflight は write/read/delete probe を通す", async () => {
@@ -203,6 +218,29 @@ describe("onedrive-oauth-session", () => {
     expect(redisMockState.sessionRawValue).not.toContain("refresh-token-plain");
   });
 
+  it("session 暗号化失敗は Redis 障害エラーに包まず専用エラーで返す", async () => {
+    const concatSpy = vi.spyOn(Buffer, "concat").mockImplementationOnce(() => {
+      throw new Error("cipher failed");
+    });
+    try {
+      await expect(
+        storeTokenForSession("session-encrypt-error", {
+          accessToken: "access-token",
+          refreshToken: "refresh-token",
+          expiresAt: Date.now() + 60_000,
+        }),
+      ).rejects.toSatisfy((error: unknown) => {
+        expect(isOAuthSessionStoreUnavailableError(error)).toBe(false);
+        expect(isOAuthSessionTokenCryptoError(error)).toBe(true);
+        expect(error).toBeInstanceOf(OAuthSessionTokenCryptoError);
+        expect((error as Error).message).toContain("OneDrive OAuth token encrypt failed");
+        return true;
+      });
+    } finally {
+      concatSpy.mockRestore();
+    }
+  });
+
   it("session 保存値は復号して元のTokenCacheを返せる", async () => {
     const expected = {
       accessToken: "access-token-roundtrip",
@@ -229,6 +267,18 @@ describe("onedrive-oauth-session", () => {
 
     await expect(getTokenForSession("session-legacy-plaintext")).resolves.toBeNull();
     expect(redisMockState.deletedSessionKeys).toContain("onedrive:session:session-legacy-plaintext");
+  });
+
+  it("復号失敗時は理由付きの警告ログを残す", async () => {
+    redisMockState.sessionRawValue = "v1.only-three.segments";
+    await expect(getTokenForSession("session-decrypt-log")).resolves.toBeNull();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "Discarding invalid OneDrive OAuth session token.",
+      expect.objectContaining({
+        sessionId: "session-decrypt-log",
+        reason: expect.any(String),
+      }),
+    );
   });
 
   it("session 値が型不整合なら null を返し、破損キーを削除する", async () => {

--- a/app/services/onedrive-oauth-session.server.test.ts
+++ b/app/services/onedrive-oauth-session.server.test.ts
@@ -50,6 +50,9 @@ vi.mock("./redis.server", () => ({
       }
       redisMockState.probeStoredValue = value;
     }
+    if (key.startsWith("onedrive:session:")) {
+      redisMockState.sessionRawValue = value;
+    }
   }),
   redisSetNxPx: vi.fn(),
   redisGet: vi.fn(async (key: string) => {
@@ -83,6 +86,7 @@ import {
   ensureOAuthSessionStoreAvailable,
   getTokenForSession,
   isOAuthSessionStoreUnavailableError,
+  storeTokenForSession,
   waitForRefreshOutcome,
 } from "./onedrive-oauth-session.server";
 
@@ -153,7 +157,8 @@ describe("onedrive-oauth-session", () => {
     redisMockState.refreshLockValue = "lock-token";
 
     setTimeout(() => {
-      redisMockState.sessionRawValue = JSON.stringify({
+      // leader 完了を模擬し、待機中followerが token を取得できる状態へ遷移させる。
+      void storeTokenForSession(sessionId, {
         accessToken: "new-access-token",
         refreshToken: "refresh-token-2",
         expiresAt: Date.now() + 60_000,
@@ -184,10 +189,46 @@ describe("onedrive-oauth-session", () => {
     }
   });
 
+  it("session 保存時は平文tokenをRedisへ保存しない", async () => {
+    await storeTokenForSession("session-encrypted", {
+      accessToken: "access-token-plain",
+      refreshToken: "refresh-token-plain",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    expect(redisMockState.sessionRawValue).toBeTruthy();
+    // v1プレフィックス付きの暗号化フォーマットで保存されることを確認する。
+    expect(redisMockState.sessionRawValue).toContain("v1.");
+    expect(redisMockState.sessionRawValue).not.toContain("access-token-plain");
+    expect(redisMockState.sessionRawValue).not.toContain("refresh-token-plain");
+  });
+
+  it("session 保存値は復号して元のTokenCacheを返せる", async () => {
+    const expected = {
+      accessToken: "access-token-roundtrip",
+      refreshToken: "refresh-token-roundtrip",
+      expiresAt: Date.now() + 60_000,
+    };
+    await storeTokenForSession("session-roundtrip", expected);
+
+    await expect(getTokenForSession("session-roundtrip")).resolves.toEqual(expected);
+  });
+
   it("session JSON 破損は 503 ではなく null を返し、破損キーを削除する", async () => {
     redisMockState.sessionRawValue = "{broken-json";
     await expect(getTokenForSession("session-corrupted-json")).resolves.toBeNull();
     expect(redisMockState.deletedSessionKeys).toContain("onedrive:session:session-corrupted-json");
+  });
+
+  it("旧平文session値は無効セッション扱いで削除する", async () => {
+    redisMockState.sessionRawValue = JSON.stringify({
+      accessToken: "legacy-access-token",
+      refreshToken: "legacy-refresh-token",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await expect(getTokenForSession("session-legacy-plaintext")).resolves.toBeNull();
+    expect(redisMockState.deletedSessionKeys).toContain("onedrive:session:session-legacy-plaintext");
   });
 
   it("session 値が型不整合なら null を返し、破損キーを削除する", async () => {

--- a/app/services/onedrive-oauth-session.server.test.ts
+++ b/app/services/onedrive-oauth-session.server.test.ts
@@ -233,7 +233,7 @@ describe("onedrive-oauth-session", () => {
         expect(isOAuthSessionStoreUnavailableError(error)).toBe(false);
         expect(isOAuthSessionTokenCryptoError(error)).toBe(true);
         expect(error).toBeInstanceOf(OAuthSessionTokenCryptoError);
-        expect((error as Error).message).toContain("OneDrive OAuth token encrypt failed");
+        expect((error as Error).message).toContain("OneDrive token crypto encrypt failed");
         return true;
       });
     } finally {
@@ -269,14 +269,19 @@ describe("onedrive-oauth-session", () => {
     expect(redisMockState.deletedSessionKeys).toContain("onedrive:session:session-legacy-plaintext");
   });
 
-  it("復号失敗時は理由付きの警告ログを残す", async () => {
-    redisMockState.sessionRawValue = "v1.only-three.segments";
+  it("復号失敗時は固定 reason code を警告ログへ残す", async () => {
+    redisMockState.sessionRawValue = [
+      "v1",
+      Buffer.alloc(12).toString("base64url"),
+      Buffer.alloc(16).toString("base64url"),
+      Buffer.from("tampered-ciphertext", "utf8").toString("base64url"),
+    ].join(".");
     await expect(getTokenForSession("session-decrypt-log")).resolves.toBeNull();
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       "Discarding invalid OneDrive OAuth session token.",
       expect.objectContaining({
         sessionId: "session-decrypt-log",
-        reason: expect.any(String),
+        reason: "decrypt-failed",
       }),
     );
   });

--- a/app/services/onedrive-oauth-session.server.test.ts
+++ b/app/services/onedrive-oauth-session.server.test.ts
@@ -9,6 +9,8 @@
  * - `waitForRefreshOutcome` が Redis read 障害を `OAuthSessionStoreUnavailableError` として返すか確認するとき。
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createCipheriv, createHash, randomBytes } from "node:crypto";
+import { resolvedSessionSecret } from "./session-secret.server";
 
 const { redisMockState } = vi.hoisted(() => ({
   redisMockState: {
@@ -31,6 +33,16 @@ const { redisMockState } = vi.hoisted(() => ({
 const { mockLoggerWarn } = vi.hoisted(() => ({
   mockLoggerWarn: vi.fn(),
 }));
+
+function encryptMalformedSessionPayload(payload: unknown): string {
+  const key = createHash("sha256").update(resolvedSessionSecret, "utf8").digest();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const plaintext = JSON.stringify(payload);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return ["v1", iv.toString("base64url"), authTag.toString("base64url"), encrypted.toString("base64url")].join(".");
+}
 
 vi.mock("./redis.server", () => ({
   redisCompareAndDelete: vi.fn(),
@@ -304,14 +316,46 @@ describe("onedrive-oauth-session", () => {
     expect(warnPayload).not.toHaveProperty("cause");
   });
 
-  it("session 値が型不整合なら null を返し、破損キーを削除する", async () => {
-    redisMockState.sessionRawValue = JSON.stringify({
+  it("accessToken 型不整合は無効セッション扱いで削除する", async () => {
+    redisMockState.sessionRawValue = encryptMalformedSessionPayload({
       accessToken: 123,
       refreshToken: "refresh-token-1",
       expiresAt: Date.now() + 60_000,
     });
-    await expect(getTokenForSession("session-invalid-shape")).resolves.toBeNull();
-    expect(redisMockState.deletedSessionKeys).toContain("onedrive:session:session-invalid-shape");
+    await expect(getTokenForSession("session-invalid-access-token-type")).resolves.toBeNull();
+    expect(redisMockState.deletedSessionKeys).toContain("onedrive:session:session-invalid-access-token-type");
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "Discarding invalid OneDrive OAuth session token.",
+      expect.objectContaining({ reason: "invalid-access-token-type" }),
+    );
+  });
+
+  it("refreshToken 型不整合は無効セッション扱いで削除する", async () => {
+    redisMockState.sessionRawValue = encryptMalformedSessionPayload({
+      accessToken: "access-token",
+      refreshToken: 123,
+      expiresAt: Date.now() + 60_000,
+    });
+    await expect(getTokenForSession("session-invalid-refresh-token-type")).resolves.toBeNull();
+    expect(redisMockState.deletedSessionKeys).toContain("onedrive:session:session-invalid-refresh-token-type");
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "Discarding invalid OneDrive OAuth session token.",
+      expect.objectContaining({ reason: "invalid-refresh-token-type" }),
+    );
+  });
+
+  it("expiresAt 型不整合は無効セッション扱いで削除する", async () => {
+    redisMockState.sessionRawValue = encryptMalformedSessionPayload({
+      accessToken: "access-token",
+      refreshToken: "refresh-token-1",
+      expiresAt: "invalid",
+    });
+    await expect(getTokenForSession("session-invalid-expires-at")).resolves.toBeNull();
+    expect(redisMockState.deletedSessionKeys).toContain("onedrive:session:session-invalid-expires-at");
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "Discarding invalid OneDrive OAuth session token.",
+      expect.objectContaining({ reason: "invalid-expires-at" }),
+    );
   });
 
   it("破損セッション削除が失敗しても null を返す", async () => {

--- a/app/services/onedrive-oauth-session.server.test.ts
+++ b/app/services/onedrive-oauth-session.server.test.ts
@@ -269,21 +269,25 @@ describe("onedrive-oauth-session", () => {
     expect(redisMockState.deletedSessionKeys).toContain("onedrive:session:session-legacy-plaintext");
   });
 
-  it("復号失敗時は固定 reason code を警告ログへ残す", async () => {
+  it("復号失敗時は生sessionIdを含めず固定 reason code を警告ログへ残す", async () => {
     redisMockState.sessionRawValue = [
       "v1",
       Buffer.alloc(12).toString("base64url"),
       Buffer.alloc(16).toString("base64url"),
       Buffer.from("tampered-ciphertext", "utf8").toString("base64url"),
     ].join(".");
-    await expect(getTokenForSession("session-decrypt-log")).resolves.toBeNull();
+    const sessionId = "session-decrypt-log";
+    await expect(getTokenForSession(sessionId)).resolves.toBeNull();
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       "Discarding invalid OneDrive OAuth session token.",
       expect.objectContaining({
-        sessionId: "session-decrypt-log",
+        sessionIdHash: expect.stringMatching(/^[0-9a-f]{12}$/),
         reason: "decrypt-failed",
       }),
     );
+    const warnPayload = mockLoggerWarn.mock.calls[0]?.[1];
+    expect(warnPayload).not.toHaveProperty("sessionId");
+    expect(JSON.stringify(warnPayload)).not.toContain(sessionId);
   });
 
   it("session 値が型不整合なら null を返し、破損キーを削除する", async () => {

--- a/app/services/onedrive-oauth-session.server.test.ts
+++ b/app/services/onedrive-oauth-session.server.test.ts
@@ -269,7 +269,7 @@ describe("onedrive-oauth-session", () => {
     expect(redisMockState.deletedSessionKeys).toContain("onedrive:session:session-legacy-plaintext");
   });
 
-  it("復号失敗時は生sessionIdを含めず固定 reason code を警告ログへ残す", async () => {
+  it("復号失敗時は生sessionIdを含めず reason/cause を警告ログへ残す", async () => {
     redisMockState.sessionRawValue = [
       "v1",
       Buffer.alloc(12).toString("base64url"),
@@ -283,11 +283,25 @@ describe("onedrive-oauth-session", () => {
       expect.objectContaining({
         sessionIdHash: expect.stringMatching(/^[0-9a-f]{12}$/),
         reason: "decrypt-failed",
+        cause: "auth-failed",
       }),
     );
     const warnPayload = mockLoggerWarn.mock.calls[0]?.[1];
     expect(warnPayload).not.toHaveProperty("sessionId");
     expect(JSON.stringify(warnPayload)).not.toContain(sessionId);
+  });
+
+  it("復号前バリデーション失敗では cause を付けない", async () => {
+    redisMockState.sessionRawValue = "legacy-plaintext";
+    await expect(getTokenForSession("session-invalid-format")).resolves.toBeNull();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "Discarding invalid OneDrive OAuth session token.",
+      expect.objectContaining({
+        reason: "invalid-segment-count",
+      }),
+    );
+    const warnPayload = mockLoggerWarn.mock.calls[0]?.[1];
+    expect(warnPayload).not.toHaveProperty("cause");
   });
 
   it("session 値が型不整合なら null を返し、破損キーを削除する", async () => {

--- a/app/services/onedrive-oauth-session.server.ts
+++ b/app/services/onedrive-oauth-session.server.ts
@@ -160,7 +160,19 @@ function parseTokenCache(value: string): ParseTokenCacheResult {
 // decryptTokenCache と parseTokenCache を分けることで、暗号化の失敗と形式の不正を区別してログに出せるようにする。
 type DecryptTokenCacheResult =
   | { cache: TokenCache; reason: null }
-  | { cache: null; reason: string };
+  | { cache: null; reason: string; cause?: string };
+
+function classifyDecryptFailureCause(error: unknown): string {
+  if (!(error instanceof Error)) return "unexpected-error";
+  const message = error.message.toLowerCase();
+  if (message.includes("authenticate") || message.includes("auth tag")) {
+    return "auth-failed";
+  }
+  if (message.includes("invalid") || message.includes("length") || message.includes("format")) {
+    return "invalid-ciphertext";
+  }
+  return "unexpected-error";
+}
 
 // 暗号化形式以外は旧形式として即無効化する（fail-closed）。
 function decryptTokenCache(value: string): DecryptTokenCacheResult {
@@ -180,8 +192,8 @@ function decryptTokenCache(value: string): DecryptTokenCacheResult {
     decipher.setAuthTag(authTag);
     const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString("utf8");
     return parseTokenCache(decrypted);
-  } catch {
-    return { cache: null, reason: "decrypt-failed" };
+  } catch (error) {
+    return { cache: null, reason: "decrypt-failed", cause: classifyDecryptFailureCause(error) };
   }
 }
 // 以下、Redis ストアを経由した OneDrive OAuth token 永続化の実装。呼び出し側はこれらの関数を通じて sessionId と token cache をやりとりする。
@@ -243,6 +255,7 @@ export async function getTokenForSession(sessionId: string | null): Promise<Toke
     logger.warn("Discarding invalid OneDrive OAuth session token.", {
       sessionIdHash: toSessionIdLogHash(sessionId),
       reason: decrypted.reason,
+      ...(decrypted.cause ? { cause: decrypted.cause } : {}),
     });
     await deleteCorruptedSessionKey(sessionId);
     return null;

--- a/app/services/onedrive-oauth-session.server.ts
+++ b/app/services/onedrive-oauth-session.server.ts
@@ -11,7 +11,10 @@
  * - 複数インスタンスで token refresh の多重実行を抑止するとき。
  */
 import { redisCompareAndDelete, redisDel, redisGet, redisSetEx, redisSetNxPx } from "./redis.server";
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+import { resolvedSessionSecret } from "./session-secret.server";
 
+// 定数定義。呼び出し側はこれらの値を知らなくていいように、必要なロジックはこのファイル内に閉じ込める。
 const SESSION_TTL_SECONDS = 60 * 60 * 24 * 7;
 const REFRESH_LOCK_POLL_INITIAL_MS = 100;
 const REFRESH_LOCK_POLL_MAX_MS = 1000;
@@ -20,6 +23,10 @@ const SESSION_KEY_PREFIX = "onedrive:session:";
 const STORE_PROBE_KEY_PREFIX = "onedrive:probe:";
 const REFRESH_LOCK_KEY_PREFIX = "onedrive:refresh-lock:";
 const REFRESH_FAILURE_KEY_PREFIX = "onedrive:refresh-failure:";
+const TOKEN_ENCRYPTION_ALGORITHM = "aes-256-gcm";
+const TOKEN_ENCRYPTION_VERSION_PREFIX = "v1";
+const TOKEN_ENCRYPTION_IV_BYTES = 12;
+const TOKEN_ENCRYPTION_AUTH_TAG_BYTES = 16;
 
 // OneDrive OAuth の server-side session に保存する最小契約。
 export type TokenCache = {
@@ -27,6 +34,8 @@ export type TokenCache = {
   refreshToken: string | null;
   expiresAt: number;
 };
+// セッション秘密鍵から32byte鍵を導出し、token暗号化/復号で共通利用する。
+const tokenEncryptionKey = createHash("sha256").update(resolvedSessionSecret, "utf8").digest();
 
 // Redis 障害を認証切れと区別するための専用エラー。
 export class OAuthSessionStoreUnavailableError extends Error {
@@ -70,6 +79,51 @@ function sleep(ms: number): Promise<void> {
     setTimeout(resolve, ms);
   });
 }
+
+function parseTokenCache(value: string): TokenCache | null {
+  const parsed = JSON.parse(value) as TokenCache;
+  if (typeof parsed.accessToken !== "string") return null;
+  if (parsed.refreshToken !== null && typeof parsed.refreshToken !== "string") return null;
+  if (typeof parsed.expiresAt !== "number" || !Number.isFinite(parsed.expiresAt)) return null;
+  return parsed;
+}
+
+function encryptTokenCache(cache: TokenCache): string {
+  const iv = randomBytes(TOKEN_ENCRYPTION_IV_BYTES);
+  const cipher = createCipheriv(TOKEN_ENCRYPTION_ALGORITHM, tokenEncryptionKey, iv);
+  const plaintext = JSON.stringify(cache);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  // バージョン.iv.authTag.ciphertext の順で保存し、将来の形式変更に備える。
+  return [
+    TOKEN_ENCRYPTION_VERSION_PREFIX,
+    iv.toString("base64url"),
+    authTag.toString("base64url"),
+    encrypted.toString("base64url"),
+  ].join(".");
+}
+
+// 暗号化形式以外は旧形式として即無効化する（fail-closed）。
+function decryptTokenCache(value: string): TokenCache | null {
+  const segments = value.split(".");
+  if (segments.length !== 4) return null;
+  if (segments[0] !== TOKEN_ENCRYPTION_VERSION_PREFIX) return null;
+
+  try {
+    const iv = Buffer.from(segments[1] ?? "", "base64url");
+    const authTag = Buffer.from(segments[2] ?? "", "base64url");
+    const encrypted = Buffer.from(segments[3] ?? "", "base64url");
+    if (iv.length !== TOKEN_ENCRYPTION_IV_BYTES) return null;
+    if (authTag.length !== TOKEN_ENCRYPTION_AUTH_TAG_BYTES) return null;
+
+    const decipher = createDecipheriv(TOKEN_ENCRYPTION_ALGORITHM, tokenEncryptionKey, iv);
+    decipher.setAuthTag(authTag);
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString("utf8");
+    return parseTokenCache(decrypted);
+  } catch {
+    return null;
+  }
+}
 // 以下、Redis ストアを経由した OneDrive OAuth token 永続化の実装。呼び出し側はこれらの関数を通じて sessionId と token cache をやりとりする。
 export async function ensureOAuthSessionStoreAvailable(): Promise<void> {
   const probeId = crypto.randomUUID();
@@ -88,7 +142,7 @@ export async function ensureOAuthSessionStoreAvailable(): Promise<void> {
 
 export async function storeTokenForSession(sessionId: string, cache: TokenCache): Promise<void> {
   try {
-    await redisSetEx(toSessionKey(sessionId), JSON.stringify(cache), SESSION_TTL_SECONDS);
+    await redisSetEx(toSessionKey(sessionId), encryptTokenCache(cache), SESSION_TTL_SECONDS);
   } catch (error) {
     throw toStoreUnavailableError("write", error);
   }
@@ -116,25 +170,12 @@ export async function getTokenForSession(sessionId: string | null): Promise<Toke
 
   if (!raw) return null;
 
-  try {
-    const parsed = JSON.parse(raw) as TokenCache;
-    if (typeof parsed.accessToken !== "string") {
-      await deleteCorruptedSessionKey(sessionId);
-      return null;
-    }
-    if (parsed.refreshToken !== null && typeof parsed.refreshToken !== "string") {
-      await deleteCorruptedSessionKey(sessionId);
-      return null;
-    }
-    if (typeof parsed.expiresAt !== "number" || !Number.isFinite(parsed.expiresAt)) {
-      await deleteCorruptedSessionKey(sessionId);
-      return null;
-    }
-    return parsed;
-  } catch {
+  const parsed = decryptTokenCache(raw);
+  if (!parsed) {
     await deleteCorruptedSessionKey(sessionId);
     return null;
   }
+  return parsed;
 }
 
 export async function deleteTokenForSession(sessionId: string): Promise<void> {

--- a/app/services/onedrive-oauth-session.server.ts
+++ b/app/services/onedrive-oauth-session.server.ts
@@ -13,6 +13,7 @@
 import { redisCompareAndDelete, redisDel, redisGet, redisSetEx, redisSetNxPx } from "./redis.server";
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
 import { resolvedSessionSecret } from "./session-secret.server";
+import { logger } from "./logger.server";
 
 // 定数定義。呼び出し側はこれらの値を知らなくていいように、必要なロジックはこのファイル内に閉じ込める。
 const SESSION_TTL_SECONDS = 60 * 60 * 24 * 7;
@@ -44,9 +45,21 @@ export class OAuthSessionStoreUnavailableError extends Error {
     this.name = "OAuthSessionStoreUnavailableError";
   }
 }
+
+// token 暗号化の失敗を Redis 障害と区別して扱う専用エラー。
+export class OAuthSessionTokenCryptoError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "OAuthSessionTokenCryptoError";
+  }
+}
 // OAuthSessionStoreUnavailableError 型ガード。これを使うことで、呼び出し側は Redis 障害と認証エラーを明確に分けて扱えるようになる。
 export function isOAuthSessionStoreUnavailableError(error: unknown): error is OAuthSessionStoreUnavailableError {
   return error instanceof OAuthSessionStoreUnavailableError;
+}
+
+export function isOAuthSessionTokenCryptoError(error: unknown): error is OAuthSessionTokenCryptoError {
+  return error instanceof OAuthSessionTokenCryptoError;
 }
 
 // Redis 上の key 命名規則を閉じ込め、呼び出し側に prefix 知識を漏らさない。
@@ -74,19 +87,22 @@ function toStoreUnavailableError(action: string, error: unknown): OAuthSessionSt
   });
 }
 
+function toTokenCryptoError(action: "encrypt" | "decrypt", error: unknown): OAuthSessionTokenCryptoError {
+  const message = error instanceof Error ? error.message : String(error);
+  return new OAuthSessionTokenCryptoError(`OneDrive OAuth token ${action} failed: ${message}`, {
+    cause: error,
+  });
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
 }
 
-function parseTokenCache(value: string): TokenCache | null {
-  const parsed = JSON.parse(value) as TokenCache;
-  if (typeof parsed.accessToken !== "string") return null;
-  if (parsed.refreshToken !== null && typeof parsed.refreshToken !== "string") return null;
-  if (typeof parsed.expiresAt !== "number" || !Number.isFinite(parsed.expiresAt)) return null;
-  return parsed;
-}
+type ParseTokenCacheResult =
+  | { cache: TokenCache; reason: null }
+  | { cache: null; reason: string };
 
 function encryptTokenCache(cache: TokenCache): string {
   const iv = randomBytes(TOKEN_ENCRYPTION_IV_BYTES);
@@ -103,25 +119,65 @@ function encryptTokenCache(cache: TokenCache): string {
   ].join(".");
 }
 
-// 暗号化形式以外は旧形式として即無効化する（fail-closed）。
-function decryptTokenCache(value: string): TokenCache | null {
-  const segments = value.split(".");
-  if (segments.length !== 4) return null;
-  if (segments[0] !== TOKEN_ENCRYPTION_VERSION_PREFIX) return null;
+// 復号後の値が正しい token cache 形式か最低限検証し、壊れた値を業務ロジックへ渡さない。
+function parseTokenCache(value: string): ParseTokenCacheResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return { cache: null, reason: "invalid-json" };
+  }
 
+  if (!parsed || typeof parsed !== "object") {
+    return { cache: null, reason: "invalid-json-shape" };
+  }
+
+  const candidate = parsed as Partial<TokenCache>;
+  if (typeof candidate.accessToken !== "string") {
+    return { cache: null, reason: "invalid-access-token-type" };
+  }
+  if (candidate.refreshToken !== null && typeof candidate.refreshToken !== "string") {
+    return { cache: null, reason: "invalid-refresh-token-type" };
+  }
+  if (typeof candidate.expiresAt !== "number" || !Number.isFinite(candidate.expiresAt)) {
+    return { cache: null, reason: "invalid-expires-at" };
+  }
+
+  return {
+    cache: {
+      accessToken: candidate.accessToken,
+      refreshToken: candidate.refreshToken,
+      expiresAt: candidate.expiresAt,
+    },
+    reason: null,
+  };
+}
+// decryptTokenCache と parseTokenCache を分けることで、暗号化の失敗と形式の不正を区別してログに出せるようにする。
+type DecryptTokenCacheResult =
+  | { cache: TokenCache; reason: null }
+  | { cache: null; reason: string };
+
+// 暗号化形式以外は旧形式として即無効化する（fail-closed）。
+function decryptTokenCache(value: string): DecryptTokenCacheResult {
+  const segments = value.split(".");
+  if (segments.length !== 4) return { cache: null, reason: "invalid-segment-count" };
+  if (segments[0] !== TOKEN_ENCRYPTION_VERSION_PREFIX) return { cache: null, reason: "unknown-version" };
+
+  // 復号前に IV と authTag の長さを検査し、壊れた値を業務ロジックへ渡さない。
   try {
     const iv = Buffer.from(segments[1] ?? "", "base64url");
     const authTag = Buffer.from(segments[2] ?? "", "base64url");
     const encrypted = Buffer.from(segments[3] ?? "", "base64url");
-    if (iv.length !== TOKEN_ENCRYPTION_IV_BYTES) return null;
-    if (authTag.length !== TOKEN_ENCRYPTION_AUTH_TAG_BYTES) return null;
+    if (iv.length !== TOKEN_ENCRYPTION_IV_BYTES) return { cache: null, reason: "invalid-iv-length" };
+    if (authTag.length !== TOKEN_ENCRYPTION_AUTH_TAG_BYTES) return { cache: null, reason: "invalid-auth-tag-length" };
 
     const decipher = createDecipheriv(TOKEN_ENCRYPTION_ALGORITHM, tokenEncryptionKey, iv);
     decipher.setAuthTag(authTag);
     const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString("utf8");
     return parseTokenCache(decrypted);
-  } catch {
-    return null;
+  } catch (error) {
+    const cryptoError = toTokenCryptoError("decrypt", error);
+    return { cache: null, reason: cryptoError.message };
   }
 }
 // 以下、Redis ストアを経由した OneDrive OAuth token 永続化の実装。呼び出し側はこれらの関数を通じて sessionId と token cache をやりとりする。
@@ -140,9 +196,17 @@ export async function ensureOAuthSessionStoreAvailable(): Promise<void> {
   }
 }
 
+// token cache を暗号化して Redis に保存する。暗号化失敗と Redis 障害を区別して専用エラーを投げる。
 export async function storeTokenForSession(sessionId: string, cache: TokenCache): Promise<void> {
+  let encryptedCache: string;
   try {
-    await redisSetEx(toSessionKey(sessionId), encryptTokenCache(cache), SESSION_TTL_SECONDS);
+    encryptedCache = encryptTokenCache(cache);
+  } catch (error) {
+    throw toTokenCryptoError("encrypt", error);
+  }
+
+  try {
+    await redisSetEx(toSessionKey(sessionId), encryptedCache, SESSION_TTL_SECONDS);
   } catch (error) {
     throw toStoreUnavailableError("write", error);
   }
@@ -157,7 +221,7 @@ async function deleteCorruptedSessionKey(sessionId: string): Promise<void> {
   }
 }
 
-// Redis から読んだ JSON を最低限検証し、壊れた値をそのまま業務ロジックへ渡さない。
+// Redis から読んだ暗号化 payload を最低限検証し、壊れた値をそのまま業務ロジックへ渡さない。
 export async function getTokenForSession(sessionId: string | null): Promise<TokenCache | null> {
   if (!sessionId) return null;
 
@@ -170,14 +234,18 @@ export async function getTokenForSession(sessionId: string | null): Promise<Toke
 
   if (!raw) return null;
 
-  const parsed = decryptTokenCache(raw);
-  if (!parsed) {
+  const decrypted = decryptTokenCache(raw);
+  if (!decrypted.cache) {
+    logger.warn("Discarding invalid OneDrive OAuth session token.", {
+      sessionId,
+      reason: decrypted.reason,
+    });
     await deleteCorruptedSessionKey(sessionId);
     return null;
   }
-  return parsed;
+  return decrypted.cache;
 }
-
+// セッション削除は認証切れと同等の扱いで、呼び出し側で必要に応じて再認証フローへ誘導する。
 export async function deleteTokenForSession(sessionId: string): Promise<void> {
   try {
     await redisDel(toSessionKey(sessionId));

--- a/app/services/onedrive-oauth-session.server.ts
+++ b/app/services/onedrive-oauth-session.server.ts
@@ -37,6 +37,7 @@ export type TokenCache = {
 };
 // セッション秘密鍵から32byte鍵を導出し、token暗号化/復号で共通利用する。
 const tokenEncryptionKey = createHash("sha256").update(resolvedSessionSecret, "utf8").digest();
+const SESSION_ID_LOG_HASH_PREFIX_LENGTH = 12;
 
 // Redis 障害を認証切れと区別するための専用エラー。
 export class OAuthSessionStoreUnavailableError extends Error {
@@ -92,6 +93,10 @@ function toTokenCryptoError(action: "encrypt" | "decrypt", error: unknown): OAut
   return new OAuthSessionTokenCryptoError(`OneDrive token crypto ${action} failed: ${message}`, {
     cause: error,
   });
+}
+// sessionId を直接ログに出すのは避け、ハッシュ化して一部だけ出すことで、障害調査に必要な識別性を保ちつつ、セキュリティリスクを減らす。
+function toSessionIdLogHash(sessionId: string): string {
+  return createHash("sha256").update(sessionId, "utf8").digest("hex").slice(0, SESSION_ID_LOG_HASH_PREFIX_LENGTH);
 }
 
 function sleep(ms: number): Promise<void> {
@@ -236,7 +241,7 @@ export async function getTokenForSession(sessionId: string | null): Promise<Toke
   const decrypted = decryptTokenCache(raw);
   if (!decrypted.cache) {
     logger.warn("Discarding invalid OneDrive OAuth session token.", {
-      sessionId,
+      sessionIdHash: toSessionIdLogHash(sessionId),
       reason: decrypted.reason,
     });
     await deleteCorruptedSessionKey(sessionId);

--- a/app/services/onedrive-oauth-session.server.ts
+++ b/app/services/onedrive-oauth-session.server.ts
@@ -89,7 +89,7 @@ function toStoreUnavailableError(action: string, error: unknown): OAuthSessionSt
 
 function toTokenCryptoError(action: "encrypt" | "decrypt", error: unknown): OAuthSessionTokenCryptoError {
   const message = error instanceof Error ? error.message : String(error);
-  return new OAuthSessionTokenCryptoError(`OneDrive OAuth token ${action} failed: ${message}`, {
+  return new OAuthSessionTokenCryptoError(`OneDrive token crypto ${action} failed: ${message}`, {
     cause: error,
   });
 }
@@ -175,9 +175,8 @@ function decryptTokenCache(value: string): DecryptTokenCacheResult {
     decipher.setAuthTag(authTag);
     const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString("utf8");
     return parseTokenCache(decrypted);
-  } catch (error) {
-    const cryptoError = toTokenCryptoError("decrypt", error);
-    return { cache: null, reason: cryptoError.message };
+  } catch {
+    return { cache: null, reason: "decrypt-failed" };
   }
 }
 // 以下、Redis ストアを経由した OneDrive OAuth token 永続化の実装。呼び出し側はこれらの関数を通じて sessionId と token cache をやりとりする。

--- a/app/services/onedrive.server.ts
+++ b/app/services/onedrive.server.ts
@@ -619,7 +619,7 @@ export async function createOneDriveServiceFromEnv(request?: Request): Promise<O
   // request がないサーバー内部経路でのみ env token を利用する。
   const accessToken = process.env.ONEDRIVE_ACCESS_TOKEN ?? "";
   // request がある API 経路では、必ずその request の OAuth セッションを使う。
-  const { getAccessToken } = await import("./onedrive-auth.server");
+  const { getAccessToken, isOneDriveOAuthTokenMissingError } = await import("./onedrive-auth.server");
   const { isOAuthSessionStoreUnavailableError } = await import("./onedrive-oauth-session.server");
 
   if (request) {
@@ -628,6 +628,9 @@ export async function createOneDriveServiceFromEnv(request?: Request): Promise<O
       return createOneDriveService({ accessToken: oauthToken });
     } catch (oauthError) {
       if (isOAuthSessionStoreUnavailableError(oauthError)) {
+        throw oauthError;
+      }
+      if (isOneDriveOAuthTokenMissingError(oauthError)) {
         throw oauthError;
       }
       const reason = oauthError instanceof Error ? oauthError.message : String(oauthError);


### PR DESCRIPTION
## Summary（必須）
- 何を変えたか:
  - OneDrive OAuth token cache の Redis 保存を平文JSONから暗号化保存（AES-256-GCM）へ変更
  - 取得時に復号 + fail-closed（不正形式/復号失敗/旧平文は無効化して削除）を実装
  - 暗号化失敗を Redis 障害と分離する専用エラー（`OAuthSessionTokenCryptoError`）を追加
  - auth-like 判定を見直し、`token crypto` 障害が認証エラー（401）へ誤分類されないよう修正
  - 復号失敗ログの `reason` を固定コード化（`decrypt-failed`）
  - 要件定義（`REQUIREMENTS.md`）に暗号化保存契約を追記
- なぜ（背景/狙い）:
  - Redis侵害時の token 漏えいリスクを下げるため
  - 障害時の分類精度（認証障害 vs 基盤/暗号処理障害）を上げるため
  - 運用時のログ集計・原因追跡を安定化するため
- Touch / Do NOT touch:
  - Touch:
    - `app/services/onedrive-oauth-session.server.ts`
    - `app/services/onedrive-oauth-session.server.test.ts`
    - `app/services/onedrive-errors.server.ts`
    - `app/services/onedrive-errors.server.test.ts`
    - `app/routes/api.onedrive.session-status.test.ts`
    - `REQUIREMENTS.md`
  - Do NOT touch:
    - OneDrive APIルート本体のレスポンス仕様
    - Redisクライアント実装
    - 依存関係

## Acceptance（Must）（必須）
- [x] Redis保存値に `accessToken` / `refreshToken` 平文が含まれない
- [x] `storeTokenForSession` の暗号化失敗は Redis 障害エラーに誤分類されない
- [x] `getTokenForSession` は復号失敗時に fail-closed で `null` を返し破損キーを削除する
- [x] `token crypto` 失敗は auth-like 判定で401に誤分類されず、非認証系として扱われる
- [x] 復号失敗ログは固定 `reason` code を出力する

## Invariants（必須）
- OAuthセッションストア障害（Redis read/write等）は `OAuthSessionStoreUnavailableError` として扱う
- token暗号化/復号処理の障害は `OAuthSessionTokenCryptoError` または固定reasonで区別可能である
- 旧平文・不正形式データは利用せず、セッション破損として安全側に倒す（fail-closed）

## Deferred / Non-goals（任意）
- 鍵ローテーションの実装（Sub-issue #43 で対応）
- 監査ログポリシーの全体整備（Sub-issue #45 で対応）

## Validation（必須）
- Commands to run（提案）:
  - [x] `npm run lint`
  - [x] `npm run typecheck`
  - [x] `npm run test -- app/services/onedrive-oauth-session.server.test.ts app/services/onedrive-errors.server.test.ts app/routes/api.onedrive.session-status.test.ts`
- Commands run（Human）:
  - `npm run lint` ✅（error 0 / warning 1: 既存 `redis.server.test.ts` の `no-explicit-any`）
  - `npm run typecheck` ✅
  - `npm run test -- app/services/onedrive-oauth-session.server.test.ts app/services/onedrive-errors.server.test.ts app/routes/api.onedrive.session-status.test.ts` ✅（3 files / 23 tests）
- Smoke check（UI/手動が必要な場合のみ）:
  - [ ] 未実施（今回はサービス層中心の変更）

## Evidence（必須）
- Logs:
  - `vitest run ...` → ✅ `Test Files 3 passed / Tests 23 passed`
  - `react-router typegen && tsc` → ✅
  - `eslint .` → ✅（warning 1）
- Screenshots:
  - Image 1: N/A
  - Image 2: N/A

## Contracts changed（変更がある場合）
- API:
  - なし（HTTP契約は変更なし）
- DB / migration:
  - Redis上の OAuth session payload 形式を変更（平文JSON → `v1.<iv>.<authTag>.<ciphertext>`）
- Events / jobs:
  - なし
- Types / schemas:
  - `OAuthSessionTokenCryptoError` を追加
  - 復号失敗時ログの `reason` を固定コード化

## Security / Trust Boundary（変更がある場合）
- 認証:
  - token欠落は auth-like（401）として維持
  - token crypto 障害は auth-like から除外し、誤再認証誘導を回避
- 認可:
  - 変更なし
- 外部入力:
  - Redis payload（セッション値）の検証を強化（segment/version/iv/authTag/JSON shape）
- 機微情報（PII / secrets / logs）:
  - token平文はRedis非保存
  - ログは固定reason code中心で、機微値を含めない

## Risk / Rollback（大きい変更は必須）
- 影響範囲:
  - OneDrive OAuth session 保存/取得経路
- 失敗時の戻し方:
  - 対象コミットをリバート（`onedrive-oauth-session` / `onedrive-errors` / tests / requirements）
- 互換性:
  - 旧平文payloadは fail-closed で無効化され、再認証が必要になる可能性あり（仕様として許容）

## Links（任意）
- Issue:
  - #42 refreshTokenを暗号化
  - #43 [Sub-issue] OAuthトークン暗号鍵のローテーション対応
  - #44 [Sub-issue] 既存平文トークンの移行/無効化方針の実装
  - #45 [Sub-issue] OAuth認証周辺の監査ログ/マスキング強化
- PR:
  - （作成時に追記）
