### PR TITLE
OneDrive OAuth/保存系の監査ログを構造化・マスキング統一

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -146,6 +146,7 @@
    - 推奨デプロイ方式: 互換性ギャップがある保存形式変更では、blue/green 等の一括切替方式を優先し、必要に応じて再認証影響を許容するメンテナンスウィンドウで実施すること。
    - 運用受入基準: 鍵ローテーション実施前に、`current` / `previous` の version と material が期待どおり設定されていることをチェックリストで確認し、確認記録を残すこと。
    - 監視要件: `unknown-key-version` および `invalid-segment-count` の警告ログ発生率を監視対象に含め、平常時しきい値を超過した場合は設定不整合またはデプロイ互換性問題としてアラートすること。
+   - 監査ログ要件: OneDrive OAuth/保存系の障害ログは構造化項目（`event`, `route`, `failureType`, `status`, `errorName`, `code`）を含め、`accessToken` / `refreshToken` / `secret` / `authorization` などの機微値は平文出力してはならない。
    - `SESSION_SECRET` が変更された場合、既存の暗号化済み OAuth セッションは復号不能となるため無効化され、再認証を要求する挙動を許容する。
    - Redis は OneDrive OAuth のサーバー側セッションストアとして必須とする。Redis が利用不能な場合、OAuth フローは fail-closed で停止し、メモリストア等への自動 fallback は行わない。
    - Redis 接続障害、timeout、読み書き失敗時は、OAuth 開始、callback、セッション参照、access token refresh を `503 Service Unavailable` として扱う。

--- a/app/routes/api.onedrive.archive.test.ts
+++ b/app/routes/api.onedrive.archive.test.ts
@@ -191,6 +191,28 @@ describe("api.onedrive.archive action", () => {
     expect(body.errorMessage).toBeUndefined();
   });
 
+  it("OneDrive accessDenied は 403 / isAuthError=false を返す", async () => {
+    onedrive.getDriveInfo.mockRejectedValue(
+      new Error("OneDrive API error (403) [code=accessDenied]: insufficient privileges"),
+    );
+
+    const response = await action({ request: buildRequest() } as never);
+    const body = (await response.json()) as {
+      ok: false;
+      error: string;
+      isAuthError: boolean;
+      errorCode?: string;
+      errorMessage?: string;
+    };
+
+    expect(response.status).toBe(403);
+    expect(body.ok).toBe(false);
+    expect(body.isAuthError).toBe(false);
+    expect(body.error).toBe("OneDrive へのアクセスが拒否されました。権限を確認してください。");
+    expect(body.errorCode).toBeUndefined();
+    expect(body.errorMessage).toBeUndefined();
+  });
+
   it("archive.json が不正JSONの場合は専用メッセージとエラーコードで502を返す", async () => {
     onedrive.getItem.mockResolvedValueOnce({ name: "PR123-Test-PR", webUrl: "https://example.com/folder" });
     onedrive.getItem.mockResolvedValueOnce({ name: "archive.json", webUrl: "https://example.com/archive" });

--- a/app/routes/api.onedrive.archive.tsx
+++ b/app/routes/api.onedrive.archive.tsx
@@ -10,6 +10,7 @@
 import type { ActionFunctionArgs } from "react-router";
 import { createGitHubServiceFromEnv, type PullRequestRef } from "../services/github.server";
 import { logger } from "../services/logger.server";
+import { buildOneDriveAuditErrorPayload } from "../services/onedrive-audit-log.server";
 import { createOneDriveServiceFromEnv } from "../services/onedrive.server";
 import { isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
 import { isOneDriveOAuthTokenMissingError } from "../services/onedrive-auth.server";
@@ -397,7 +398,13 @@ export async function action({ request }: ActionFunctionArgs) {
   } catch (error) {
     if (isOAuthSessionStoreUnavailableError(error)) {
       logger.error("OneDrive archive fetch failed due to session store outage.", {
-        message: error.message,
+        ...buildOneDriveAuditErrorPayload({
+          event: "onedrive.session-store-unavailable",
+          route: "api/onedrive/archive",
+          error,
+          status: 503,
+          failureType: "session-store",
+        }),
       });
       return Response.json(
         {
@@ -441,6 +448,31 @@ export async function action({ request }: ActionFunctionArgs) {
     const message = isAuthLike
       ? "OneDrive 認証が切れています。再認証してから再実行してください。"
       : "OneDrive 上の archive.json 取得に失敗しました。しばらくしてから再実行してください。";
+    if (isAuthLike) {
+      // 認証切れは運用上の想定内イベントとして warn で監査する。
+      logger.warn(
+        "OneDrive archive fetch auth-like failure.",
+        buildOneDriveAuditErrorPayload({
+          event: "onedrive.auth-failure",
+          route: "api/onedrive/archive",
+          error,
+          status: 401,
+          failureType: "onedrive-auth",
+        }),
+      );
+    } else {
+      // 非認証系は保存/参照障害として error で検知可能にする。
+      logger.error(
+        "OneDrive archive fetch failed.",
+        buildOneDriveAuditErrorPayload({
+          event: "onedrive.archive-fetch-failed",
+          route: "api/onedrive/archive",
+          error,
+          status: 502,
+          failureType: "onedrive-non-auth",
+        }),
+      );
+    }
 
     return Response.json(
       {

--- a/app/routes/api.onedrive.archive.tsx
+++ b/app/routes/api.onedrive.archive.tsx
@@ -12,7 +12,7 @@ import { createGitHubServiceFromEnv, type PullRequestRef } from "../services/git
 import { logger } from "../services/logger.server";
 import { buildOneDriveAuditErrorPayload } from "../services/onedrive-audit-log.server";
 import { createOneDriveServiceFromEnv } from "../services/onedrive.server";
-import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
+import { extractOneDriveError, isOneDriveAuthLikeError, resolveOneDriveAuthStatus } from "../services/onedrive-errors.server";
 import { isOneDriveOAuthTokenMissingError } from "../services/onedrive-auth.server";
 import { validatePrRefInput } from "../services/validation";
 import { verifyCsrfToken } from "../services/csrf.server";
@@ -446,7 +446,7 @@ export async function action({ request }: ActionFunctionArgs) {
     }
     const isAuthLike = isOneDriveOAuthTokenMissingError(error) || isOneDriveAuthLikeError(rawMessage);
     const parsed = extractOneDriveError(rawMessage);
-    const authStatus = parsed.code === "accessDenied" ? 403 : 401;
+    const authStatus = resolveOneDriveAuthStatus(rawMessage, parsed.code);
     const message = isAuthLike
       ? authStatus === 403
         ? "OneDrive へのアクセスが拒否されました。権限を確認してください。"

--- a/app/routes/api.onedrive.archive.tsx
+++ b/app/routes/api.onedrive.archive.tsx
@@ -12,7 +12,7 @@ import { createGitHubServiceFromEnv, type PullRequestRef } from "../services/git
 import { logger } from "../services/logger.server";
 import { buildOneDriveAuditErrorPayload } from "../services/onedrive-audit-log.server";
 import { createOneDriveServiceFromEnv } from "../services/onedrive.server";
-import { isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
+import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
 import { isOneDriveOAuthTokenMissingError } from "../services/onedrive-auth.server";
 import { validatePrRefInput } from "../services/validation";
 import { verifyCsrfToken } from "../services/csrf.server";
@@ -445,8 +445,12 @@ export async function action({ request }: ActionFunctionArgs) {
       );
     }
     const isAuthLike = isOneDriveOAuthTokenMissingError(error) || isOneDriveAuthLikeError(rawMessage);
+    const parsed = extractOneDriveError(rawMessage);
+    const authStatus = parsed.code === "accessDenied" ? 403 : 401;
     const message = isAuthLike
-      ? "OneDrive 認証が切れています。再認証してから再実行してください。"
+      ? authStatus === 403
+        ? "OneDrive へのアクセスが拒否されました。権限を確認してください。"
+        : "OneDrive 認証が切れています。再認証してから再実行してください。"
       : "OneDrive 上の archive.json 取得に失敗しました。しばらくしてから再実行してください。";
     if (isAuthLike) {
       // 認証切れは運用上の想定内イベントとして warn で監査する。
@@ -456,8 +460,12 @@ export async function action({ request }: ActionFunctionArgs) {
           event: "onedrive.auth-failure",
           route: "api/onedrive/archive",
           error,
-          status: 401,
+          status: authStatus,
           failureType: "onedrive-auth",
+          extra: {
+            code: parsed.code ?? null,
+            detail: parsed.message ?? null,
+          },
         }),
       );
     } else {
@@ -478,11 +486,11 @@ export async function action({ request }: ActionFunctionArgs) {
       {
         ok: false,
         error: message,
-        isAuthError: isAuthLike,
+        isAuthError: isAuthLike && authStatus === 401,
         errorCode: undefined,
         errorMessage: undefined,
       } satisfies ApiOneDriveArchiveResponse,
-      { status: isAuthLike ? 401 : 502 },
+      { status: isAuthLike ? authStatus : 502 },
     );
   }
 }

--- a/app/routes/api.onedrive.evidence-image.test.ts
+++ b/app/routes/api.onedrive.evidence-image.test.ts
@@ -191,12 +191,23 @@ describe("api.onedrive.evidence-image loader", () => {
   });
 
   it("429 は Retry-After を返す", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     onedrive.getBinary.mockRejectedValue(new OneDriveApiError("throttled", 429, "activityLimitReached", 8));
     const request = buildEvidenceRequest("project/repo/PullRequests/PR1-test/imgs/a.png");
     const response = await loader({ request } as never);
 
     expect(response.status).toBe(429);
     expect(response.headers.get("retry-after")).toBe("8");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "OneDrive evidence-image rate limited.",
+      expect.objectContaining({
+        event: "onedrive.evidence-image-fetch-failed",
+        route: "api/onedrive/evidence-image",
+        status: 429,
+        failureType: "onedrive-rate-limit",
+      }),
+    );
+    warnSpy.mockRestore();
   });
 
   it("429 の Retry-After が日時形式でもそのまま返す", async () => {

--- a/app/routes/api.onedrive.evidence-image.test.ts
+++ b/app/routes/api.onedrive.evidence-image.test.ts
@@ -157,6 +157,7 @@ describe("api.onedrive.evidence-image loader", () => {
   });
 
   it("権限不足は 403 を返す", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     onedrive.getBinary.mockRejectedValue(new OneDriveApiError("forbidden", 403, "accessDenied"));
     const request = buildEvidenceRequest("project/repo/PullRequests/PR1-test/imgs/a.png");
     const response = await loader({ request } as never);
@@ -164,6 +165,36 @@ describe("api.onedrive.evidence-image loader", () => {
 
     expect(response.status).toBe(403);
     expect(body).toBe("onedrive access denied");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "OneDrive evidence-image auth-like failure.",
+      expect.objectContaining({
+        event: "onedrive.auth-failure",
+        route: "api/onedrive/evidence-image",
+        status: 403,
+      }),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("OneDriveApiError の 401 は監査ログを出して 401 を返す", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    onedrive.getBinary.mockRejectedValue(new OneDriveApiError("token expired", 401, "InvalidAuthenticationToken"));
+
+    const request = buildEvidenceRequest("project/repo/PullRequests/PR1-test/imgs/a.png");
+    const response = await loader({ request } as never);
+    const body = await response.text();
+
+    expect(response.status).toBe(401);
+    expect(body).toBe("onedrive auth required");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "OneDrive evidence-image auth-like failure.",
+      expect.objectContaining({
+        event: "onedrive.auth-failure",
+        route: "api/onedrive/evidence-image",
+        status: 401,
+      }),
+    );
+    warnSpy.mockRestore();
   });
 
   it("非画像 content-type は 415 を返す", async () => {

--- a/app/routes/api.onedrive.evidence-image.tsx
+++ b/app/routes/api.onedrive.evidence-image.tsx
@@ -9,6 +9,7 @@
  */
 import type { LoaderFunctionArgs } from "react-router";
 import { logger } from "../services/logger.server";
+import { buildOneDriveAuditErrorPayload } from "../services/onedrive-audit-log.server";
 import { createOneDriveServiceFromEnv, OneDriveApiError } from "../services/onedrive.server";
 import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
 import { isOneDriveOAuthTokenMissingError } from "../services/onedrive-auth.server";
@@ -109,7 +110,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
   } catch (error) {
     if (isOAuthSessionStoreUnavailableError(error)) {
       logger.error("OneDrive evidence-image failed due to session store outage.", {
-        message: error.message,
+        ...buildOneDriveAuditErrorPayload({
+          event: "onedrive.session-store-unavailable",
+          route: "api/onedrive/evidence-image",
+          error,
+          status: 503,
+          failureType: "session-store",
+        }),
       });
       return textResponse(503, "onedrive session store unavailable");
     }
@@ -144,9 +151,30 @@ export async function loader({ request }: LoaderFunctionArgs) {
     if (isAuthLike) {
       const parsed = extractOneDriveError(rawMessage);
       const status = parsed.code === "accessDenied" ? 403 : 401;
+      // auth-like でも accessDenied は 403 へ正規化して UI 側の分岐を安定させる。
+      logger.warn(
+        "OneDrive evidence-image auth-like failure.",
+        buildOneDriveAuditErrorPayload({
+          event: "onedrive.auth-failure",
+          route: "api/onedrive/evidence-image",
+          error,
+          status,
+          failureType: "onedrive-auth",
+        }),
+      );
       return textResponse(status, status === 403 ? "onedrive access denied" : "onedrive auth required");
     }
 
+    logger.error(
+      "OneDrive evidence-image fetch failed.",
+      buildOneDriveAuditErrorPayload({
+        event: "onedrive.evidence-image-fetch-failed",
+        route: "api/onedrive/evidence-image",
+        error,
+        status: 502,
+        failureType: "onedrive-non-auth",
+      }),
+    );
     return textResponse(502, "failed to fetch evidence image");
   }
 }

--- a/app/routes/api.onedrive.evidence-image.tsx
+++ b/app/routes/api.onedrive.evidence-image.tsx
@@ -131,6 +131,22 @@ export async function loader({ request }: LoaderFunctionArgs) {
         return textResponse(401, "onedrive auth required");
       }
       if (error.status === 429) {
+        // OneDrive APIのレートリミットに達した場合は、429を返す。これにより、フロントエンドは一時的な過負荷状態であることを認識し、適切にユーザーにフィードバックできるようになる。
+        logger.warn(
+          "OneDrive evidence-image rate limited.",
+          buildOneDriveAuditErrorPayload({
+            event: "onedrive.evidence-image-fetch-failed",
+            route: "api/onedrive/evidence-image",
+            error,
+            status: 429,
+            failureType: "onedrive-rate-limit",
+            extra: {
+              retryAfterRaw: error.retryAfterRaw ?? null,
+              retryAfterSeconds: error.retryAfterSeconds ?? null,
+              retryAfterAtIso: error.retryAfterAtIso ?? null,
+            },
+          }),
+        );
         return textResponse(429, "onedrive rate limited", {
           ...(error.retryAfterRaw
             ? { "Retry-After": error.retryAfterRaw }

--- a/app/routes/api.onedrive.evidence-image.tsx
+++ b/app/routes/api.onedrive.evidence-image.tsx
@@ -11,7 +11,7 @@ import type { LoaderFunctionArgs } from "react-router";
 import { logger } from "../services/logger.server";
 import { buildOneDriveAuditErrorPayload } from "../services/onedrive-audit-log.server";
 import { createOneDriveServiceFromEnv, OneDriveApiError } from "../services/onedrive.server";
-import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
+import { extractOneDriveError, isOneDriveAuthLikeError, resolveOneDriveAuthStatus } from "../services/onedrive-errors.server";
 import { isOneDriveOAuthTokenMissingError } from "../services/onedrive-auth.server";
 import { isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import {
@@ -192,7 +192,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const isAuthLike = isOneDriveOAuthTokenMissingError(error) || isOneDriveAuthLikeError(rawMessage);
     if (isAuthLike) {
       const parsed = extractOneDriveError(rawMessage);
-      const status = parsed.code === "accessDenied" ? 403 : 401;
+      const status = resolveOneDriveAuthStatus(rawMessage, parsed.code);
       // auth-like でも accessDenied は 403 へ正規化して UI 側の分岐を安定させる。
       logger.warn(
         "OneDrive evidence-image auth-like failure.",

--- a/app/routes/api.onedrive.evidence-image.tsx
+++ b/app/routes/api.onedrive.evidence-image.tsx
@@ -125,9 +125,35 @@ export async function loader({ request }: LoaderFunctionArgs) {
         return textResponse(404, "evidence image not found");
       }
       if (error.status === 403) {
+        logger.warn(
+          "OneDrive evidence-image auth-like failure.",
+          buildOneDriveAuditErrorPayload({
+            event: "onedrive.auth-failure",
+            route: "api/onedrive/evidence-image",
+            error,
+            status: 403,
+            failureType: "onedrive-auth",
+            extra: {
+              code: error.code ?? null,
+            },
+          }),
+        );
         return textResponse(403, "onedrive access denied");
       }
       if (error.status === 401) {
+        logger.warn(
+          "OneDrive evidence-image auth-like failure.",
+          buildOneDriveAuditErrorPayload({
+            event: "onedrive.auth-failure",
+            route: "api/onedrive/evidence-image",
+            error,
+            status: 401,
+            failureType: "onedrive-auth",
+            extra: {
+              code: error.code ?? null,
+            },
+          }),
+        );
         return textResponse(401, "onedrive auth required");
       }
       if (error.status === 429) {

--- a/app/routes/api.onedrive.session-status.test.ts
+++ b/app/routes/api.onedrive.session-status.test.ts
@@ -102,6 +102,28 @@ describe("api.onedrive.session-status loader", () => {
     expect(body.isAuthError).toBe(true);
   });
 
+  it("認証エラー詳細はレスポンスへ露出しない", async () => {
+    vi.mocked(getAccessToken).mockRejectedValue(
+      new Error("OneDrive API error (401) [code=InvalidAuthenticationToken]: token=super-secret-token"),
+    );
+
+    const response = await loader({ request: buildRequest() } as never);
+    const body = (await response.json()) as {
+      ok: false;
+      isAuthError: boolean;
+      error: string;
+      errorCode?: string;
+      errorMessage?: string;
+    };
+
+    expect(response.status).toBe(401);
+    expect(body.ok).toBe(false);
+    expect(body.isAuthError).toBe(true);
+    expect(body.errorCode).toBe("InvalidAuthenticationToken");
+    expect(body.errorMessage).toBeUndefined();
+    expect(body.error).toBe("OneDrive 認証が有効ではありません。Connect OneDrive から再認証してください。");
+  });
+
   it("token crypto 障害は認証エラー扱いせず502を返す", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.mocked(getAccessToken).mockRejectedValue(new Error("OneDrive token crypto encrypt failed: cipher failed"));

--- a/app/routes/api.onedrive.session-status.test.ts
+++ b/app/routes/api.onedrive.session-status.test.ts
@@ -102,6 +102,28 @@ describe("api.onedrive.session-status loader", () => {
     expect(body.isAuthError).toBe(true);
   });
 
+  it("accessDenied は 403 / isAuthError=false を返す", async () => {
+    vi.mocked(getAccessToken).mockRejectedValue(
+      new Error("OneDrive API error (403) [code=accessDenied]: insufficient privileges"),
+    );
+
+    const response = await loader({ request: buildRequest() } as never);
+    const body = (await response.json()) as {
+      ok: false;
+      isAuthError: boolean;
+      error: string;
+      errorCode?: string;
+      errorMessage?: string;
+    };
+
+    expect(response.status).toBe(403);
+    expect(body.ok).toBe(false);
+    expect(body.isAuthError).toBe(false);
+    expect(body.errorCode).toBe("accessDenied");
+    expect(body.errorMessage).toBeUndefined();
+    expect(body.error).toBe("OneDrive へのアクセスが拒否されました。権限を確認してください。");
+  });
+
   it("認証エラー詳細はレスポンスへ露出しない", async () => {
     vi.mocked(getAccessToken).mockRejectedValue(
       new Error("OneDrive API error (401) [code=InvalidAuthenticationToken]: token=super-secret-token"),

--- a/app/routes/api.onedrive.session-status.tsx
+++ b/app/routes/api.onedrive.session-status.tsx
@@ -11,7 +11,7 @@
 import type { LoaderFunctionArgs } from "react-router";
 import { logger } from "../services/logger.server";
 import { buildOneDriveAuditErrorPayload } from "../services/onedrive-audit-log.server";
-import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
+import { extractOneDriveError, isOneDriveAuthLikeError, resolveOneDriveAuthStatus } from "../services/onedrive-errors.server";
 import { getAccessToken, isOneDriveOAuthTokenMissingError } from "../services/onedrive-auth.server";
 import { isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import { createOneDriveService } from "../services/onedrive.server";
@@ -70,7 +70,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const rawMessage = error instanceof Error ? error.message : "Unknown error";
     const parsed = extractOneDriveError(rawMessage);
     const isAuthLike = isOneDriveOAuthTokenMissingError(error) || isOneDriveAuthLikeError(rawMessage);
-    const authStatus = parsed.code === "accessDenied" ? 403 : 401;
+    const authStatus = resolveOneDriveAuthStatus(rawMessage, parsed.code);
     const message = isAuthLike
       ? authStatus === 403
         ? "OneDrive へのアクセスが拒否されました。権限を確認してください。"

--- a/app/routes/api.onedrive.session-status.tsx
+++ b/app/routes/api.onedrive.session-status.tsx
@@ -10,6 +10,7 @@
  */
 import type { LoaderFunctionArgs } from "react-router";
 import { logger } from "../services/logger.server";
+import { buildOneDriveAuditErrorPayload } from "../services/onedrive-audit-log.server";
 import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
 import { getAccessToken, isOneDriveOAuthTokenMissingError } from "../services/onedrive-auth.server";
 import { isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
@@ -49,7 +50,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
   } catch (error) {
     if (isOAuthSessionStoreUnavailableError(error)) {
       logger.error("OneDrive session-status failed due to session store outage.", {
-        message: error.message,
+        ...buildOneDriveAuditErrorPayload({
+          event: "onedrive.session-store-unavailable",
+          route: "api/onedrive/session-status",
+          error,
+          status: 503,
+          failureType: "session-store",
+        }),
       });
       return Response.json(
         {
@@ -63,21 +70,39 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const rawMessage = error instanceof Error ? error.message : "Unknown error";
     const parsed = extractOneDriveError(rawMessage);
     const isAuthLike = isOneDriveOAuthTokenMissingError(error) || isOneDriveAuthLikeError(rawMessage);
-
-    const hasDetail = Boolean(parsed.code || parsed.message);
     const message = isAuthLike
-      ? hasDetail
-        ? `${parsed.code ?? "UNKNOWN"}: ${parsed.message ?? rawMessage}`
-        : "OneDrive 認証が有効ではありません。Connect OneDrive から再認証してください。"
+      ? "OneDrive 認証が有効ではありません。Connect OneDrive から再認証してください。"
       : "OneDrive セッション確認に失敗しました。しばらくしてから再実行してください。";
-    if (!isAuthLike) {
-      // 認証エラーの可能性が低いエラーは、内部的な詳細をログに残す。
-      // これにより、ユーザーには定型のエラーメッセージのみを返しつつ、開発者は問題の診断に必要な情報を得られるようになる。
-      logger.error("OneDrive session-status failed.", {
-        message: rawMessage,
-        code: parsed.code,
-        detail: parsed.message,
-      });
+    if (isAuthLike) {
+      logger.warn(
+        "OneDrive session-status auth-like failure.",
+        buildOneDriveAuditErrorPayload({
+          event: "onedrive.auth-failure",
+          route: "api/onedrive/session-status",
+          error,
+          status: 401,
+          failureType: "onedrive-auth",
+          extra: {
+            code: parsed.code ?? null,
+            detail: parsed.message ?? null,
+          },
+        }),
+      );
+    } else {
+      logger.error(
+        "OneDrive session-status failed.",
+        buildOneDriveAuditErrorPayload({
+          event: "onedrive.session-status-failed",
+          route: "api/onedrive/session-status",
+          error,
+          status: 502,
+          failureType: "onedrive-non-auth",
+          extra: {
+            code: parsed.code ?? null,
+            detail: parsed.message ?? null,
+          },
+        }),
+      );
     }
 
     return Response.json(
@@ -86,7 +111,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
         error: message,
         isAuthError: isAuthLike,
         errorCode: isAuthLike ? parsed.code : undefined,
-        errorMessage: isAuthLike ? parsed.message ?? rawMessage : undefined,
+        // 詳細文は機微情報混入リスクがあるためレスポンスには載せない。
+        errorMessage: undefined,
       } satisfies ApiOneDriveSessionStatusResponse,
       { status: isAuthLike ? 401 : 502 },
     );

--- a/app/routes/api.onedrive.session-status.tsx
+++ b/app/routes/api.onedrive.session-status.tsx
@@ -70,8 +70,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const rawMessage = error instanceof Error ? error.message : "Unknown error";
     const parsed = extractOneDriveError(rawMessage);
     const isAuthLike = isOneDriveOAuthTokenMissingError(error) || isOneDriveAuthLikeError(rawMessage);
+    const authStatus = parsed.code === "accessDenied" ? 403 : 401;
     const message = isAuthLike
-      ? "OneDrive 認証が有効ではありません。Connect OneDrive から再認証してください。"
+      ? authStatus === 403
+        ? "OneDrive へのアクセスが拒否されました。権限を確認してください。"
+        : "OneDrive 認証が有効ではありません。Connect OneDrive から再認証してください。"
       : "OneDrive セッション確認に失敗しました。しばらくしてから再実行してください。";
     if (isAuthLike) {
       logger.warn(
@@ -80,7 +83,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
           event: "onedrive.auth-failure",
           route: "api/onedrive/session-status",
           error,
-          status: 401,
+          status: authStatus,
           failureType: "onedrive-auth",
           extra: {
             code: parsed.code ?? null,
@@ -109,12 +112,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
       {
         ok: false,
         error: message,
-        isAuthError: isAuthLike,
+        isAuthError: isAuthLike && authStatus === 401,
         errorCode: isAuthLike ? parsed.code : undefined,
         // 詳細文は機微情報混入リスクがあるためレスポンスには載せない。
         errorMessage: undefined,
       } satisfies ApiOneDriveSessionStatusResponse,
-      { status: isAuthLike ? 401 : 502 },
+      { status: isAuthLike ? authStatus : 502 },
     );
   }
 }

--- a/app/routes/api.onedrive.upload.test.ts
+++ b/app/routes/api.onedrive.upload.test.ts
@@ -272,6 +272,28 @@ describe("api.onedrive.upload action", () => {
     expect(body.errorMessage).toBeUndefined();
   });
 
+  it("OneDrive accessDenied は 403 / isAuthError=false で返す", async () => {
+    onedrive.getDriveInfo.mockRejectedValue(
+      new Error("OneDrive API error (403) [code=accessDenied]: insufficient privileges"),
+    );
+
+    const response = await action({ request: buildRequest() } as never);
+    const body = (await response.json()) as {
+      ok: false;
+      isAuthError: boolean;
+      error: string;
+      errorCode?: string;
+      errorMessage?: string;
+    };
+
+    expect(response.status).toBe(403);
+    expect(body.ok).toBe(false);
+    expect(body.isAuthError).toBe(false);
+    expect(body.error).toBe("OneDrive へのアクセスが拒否されました。権限を確認してください。");
+    expect(body.errorCode).toBeUndefined();
+    expect(body.errorMessage).toBeUndefined();
+  });
+
   it("Redis障害は503で返し、保存処理へ進まない", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     onedrive.getDriveInfo.mockRejectedValue(new OAuthSessionStoreUnavailableError("redis down"));

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -485,7 +485,9 @@ export async function action({ request }: ActionFunctionArgs) {
       );
     }
     const message = isAuthLike
-      ? "OneDrive 認証が切れています。再認証してから保存をやり直してください。"
+      ? parsed.code === "accessDenied"
+        ? "OneDrive へのアクセスが拒否されました。権限を確認してください。"
+        : "OneDrive 認証が切れています。再認証してから保存をやり直してください。"
       : "OneDrive への保存に失敗しました。しばらくしてから再実行してください。";
     // 認証エラーっぽい場合でも、エラーコードや詳細メッセージがない場合は定型の再認証メッセージを返す。これにより、OneDrive API のエラーレスポンスの形式が変わったり、予期しないエラーが発生した場合でも、ユーザーには再認証が必要な可能性があることを伝えることができる。
     if (!isAuthLike) {
@@ -511,7 +513,7 @@ export async function action({ request }: ActionFunctionArgs) {
           event: "onedrive.auth-failure",
           route: "api/onedrive/upload",
           error,
-          status: 401,
+          status: parsed.code === "accessDenied" ? 403 : 401,
           failureType: "onedrive-auth",
           extra: {
             code: parsed.code ?? null,
@@ -520,7 +522,7 @@ export async function action({ request }: ActionFunctionArgs) {
         }),
       );
     }
-    const status = isAuthLike ? 401 : 502;
+    const status = isAuthLike ? (parsed.code === "accessDenied" ? 403 : 401) : 502;
     return Response.json(
       {
         ok: false,

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -15,7 +15,7 @@ import {
 import { getHttpStatus } from "../services/http-status";
 import { logger } from "../services/logger.server";
 import { buildOneDriveAuditErrorPayload, sanitizeAuditPayload } from "../services/onedrive-audit-log.server";
-import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
+import { extractOneDriveError, isOneDriveAuthLikeError, resolveOneDriveAuthStatus } from "../services/onedrive-errors.server";
 import { isOneDriveOAuthTokenMissingError } from "../services/onedrive-auth.server";
 import { isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import { createOneDriveServiceFromEnv, OneDriveApiError } from "../services/onedrive.server";
@@ -484,8 +484,9 @@ export async function action({ request }: ActionFunctionArgs) {
         { status: 502 },
       );
     }
+    const authStatus = resolveOneDriveAuthStatus(rawMessage, parsed.code);
     const message = isAuthLike
-      ? parsed.code === "accessDenied"
+      ? authStatus === 403
         ? "OneDrive へのアクセスが拒否されました。権限を確認してください。"
         : "OneDrive 認証が切れています。再認証してから保存をやり直してください。"
       : "OneDrive への保存に失敗しました。しばらくしてから再実行してください。";
@@ -513,7 +514,7 @@ export async function action({ request }: ActionFunctionArgs) {
           event: "onedrive.auth-failure",
           route: "api/onedrive/upload",
           error,
-          status: parsed.code === "accessDenied" ? 403 : 401,
+          status: authStatus,
           failureType: "onedrive-auth",
           extra: {
             code: parsed.code ?? null,
@@ -522,7 +523,7 @@ export async function action({ request }: ActionFunctionArgs) {
         }),
       );
     }
-    const status = isAuthLike ? (parsed.code === "accessDenied" ? 403 : 401) : 502;
+    const status = isAuthLike ? authStatus : 502;
     return Response.json(
       {
         ok: false,

--- a/app/routes/api.onedrive.upload.tsx
+++ b/app/routes/api.onedrive.upload.tsx
@@ -14,6 +14,7 @@ import {
 } from "../services/github.server";
 import { getHttpStatus } from "../services/http-status";
 import { logger } from "../services/logger.server";
+import { buildOneDriveAuditErrorPayload, sanitizeAuditPayload } from "../services/onedrive-audit-log.server";
 import { extractOneDriveError, isOneDriveAuthLikeError } from "../services/onedrive-errors.server";
 import { isOneDriveOAuthTokenMissingError } from "../services/onedrive-auth.server";
 import { isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
@@ -258,8 +259,12 @@ export async function action({ request }: ActionFunctionArgs) {
               evidenceDeleteFailureCount += 1;
               lastEvidenceDeleteFailureReason = reason.trim() || "unknown";
               logger.warn("OneDrive rollback image cleanup skipped.", {
-                imagePath,
-                reason,
+                ...sanitizeAuditPayload({
+                  event: "onedrive.rollback-image-cleanup-skipped",
+                  route: "api/onedrive/upload",
+                  imagePath,
+                  reason,
+                }),
               });
             }
           }
@@ -283,8 +288,12 @@ export async function action({ request }: ActionFunctionArgs) {
                 ? imagesFolderCleanupError.message
                 : String(imagesFolderCleanupError);
             logger.warn("OneDrive rollback images folder cleanup skipped.", {
-              folderPath,
-              reason,
+              ...sanitizeAuditPayload({
+                event: "onedrive.rollback-images-folder-cleanup-skipped",
+                route: "api/onedrive/upload",
+                folderPath,
+                reason,
+              }),
             });
           }
         }
@@ -300,8 +309,12 @@ export async function action({ request }: ActionFunctionArgs) {
               const reason = folderCleanupError instanceof Error ? folderCleanupError.message : String(folderCleanupError);
               rollbackFolderCleanup = `failed (${reason.trim() || "unknown"})`;
               logger.warn("OneDrive rollback folder cleanup skipped.", {
-                folderPath,
-                reason,
+                ...sanitizeAuditPayload({
+                  event: "onedrive.rollback-folder-cleanup-skipped",
+                  route: "api/onedrive/upload",
+                  folderPath,
+                  reason,
+                }),
               });
             }
           } catch (rollbackError) {
@@ -355,7 +368,13 @@ export async function action({ request }: ActionFunctionArgs) {
   } catch (error) {
     if (isOAuthSessionStoreUnavailableError(error)) {
       logger.error("OneDrive upload failed due to session store outage.", {
-        message: error.message,
+        ...buildOneDriveAuditErrorPayload({
+          event: "onedrive.session-store-unavailable",
+          route: "api/onedrive/upload",
+          error,
+          status: 503,
+          failureType: "session-store",
+        }),
       });
       return Response.json(
         {
@@ -429,6 +448,16 @@ export async function action({ request }: ActionFunctionArgs) {
     }
     // OneDrive への保存処理中のエラーは、認証エラーかどうかに関わらず基本的には 502 として返す。ただし、認証エラーと判断できる場合は 401 とする。
     if (failureDomain === "internal") {
+      logger.error(
+        "OneDrive upload failed due to internal failure.",
+        buildOneDriveAuditErrorPayload({
+          event: "onedrive.internal-failure",
+          route: "api/onedrive/upload",
+          error,
+          status: 500,
+          failureType: "internal",
+        }),
+      );
       return Response.json(
         {
           ok: false,
@@ -460,11 +489,36 @@ export async function action({ request }: ActionFunctionArgs) {
       : "OneDrive への保存に失敗しました。しばらくしてから再実行してください。";
     // 認証エラーっぽい場合でも、エラーコードや詳細メッセージがない場合は定型の再認証メッセージを返す。これにより、OneDrive API のエラーレスポンスの形式が変わったり、予期しないエラーが発生した場合でも、ユーザーには再認証が必要な可能性があることを伝えることができる。
     if (!isAuthLike) {
-      logger.error("OneDrive upload failed.", {
-        message: rawMessage,
-        code: parsed.code,
-        detail: parsed.message,
-      });
+      logger.error(
+        "OneDrive upload failed.",
+        buildOneDriveAuditErrorPayload({
+          event: "onedrive.upload-failed",
+          route: "api/onedrive/upload",
+          error,
+          status: 502,
+          failureType: "onedrive-non-auth",
+          extra: {
+            code: parsed.code ?? null,
+            detail: parsed.message ?? null,
+          },
+        }),
+      );
+    } else {
+      // 認証系は障害ではなく再認証導線の対象なので warn で記録する。
+      logger.warn(
+        "OneDrive upload auth-like failure.",
+        buildOneDriveAuditErrorPayload({
+          event: "onedrive.auth-failure",
+          route: "api/onedrive/upload",
+          error,
+          status: 401,
+          failureType: "onedrive-auth",
+          extra: {
+            code: parsed.code ?? null,
+            detail: parsed.message ?? null,
+          },
+        }),
+      );
     }
     const status = isAuthLike ? 401 : 502;
     return Response.json(

--- a/app/routes/auth.onedrive.callback.test.ts
+++ b/app/routes/auth.onedrive.callback.test.ts
@@ -70,19 +70,34 @@ describe("auth.onedrive.callback loader", () => {
   });
 
   it("OAuth provider error時はトップへリダイレクトする", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const request = new Request(
-      "https://localhost:5173/auth/onedrive/callback?error=access_denied&error_description=sensitive-details&error_codes=12345",
+      "https://localhost:5173/auth/onedrive/callback?error=access_denied&error_description=token%3Dsuper-secret-token&error_codes=12345",
     );
 
     const response = await loader({ request });
     expect(response.status).toBe(302);
     expect(response.headers.get("Location")).toBe("/?onedrive=oauth_failed");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "OneDrive OAuth callback returned an error.",
+      expect.objectContaining({
+        errorDescription: expect.not.stringContaining("super-secret-token"),
+      }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      "OneDrive OAuth callback returned an error.",
+      expect.objectContaining({
+        errorDescription: expect.stringContaining("[REDACTED]"),
+      }),
+    );
+    warnSpy.mockRestore();
   });
 
   it("token交換失敗時はトップへリダイレクトする", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.mocked(onedriveOAuthStateCookie.parse).mockResolvedValue("bind-a.nonce-1");
     vi.mocked(onedriveOAuthBindCookie.parse).mockResolvedValue("bind-a");
-    vi.mocked(exchangeCodeForToken).mockRejectedValue(new Error("sensitive-token-error"));
+    vi.mocked(exchangeCodeForToken).mockRejectedValue(new Error("refresh_token=very-secret-refresh-token"));
 
     const request = new Request(
       "https://localhost:5173/auth/onedrive/callback?code=test-code&state=bind-a.nonce-1",
@@ -92,6 +107,19 @@ describe("auth.onedrive.callback loader", () => {
     const response = await loader({ request });
     expect(response.status).toBe(302);
     expect(response.headers.get("Location")).toBe("/?onedrive=oauth_failed");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "OneDrive OAuth token exchange failed.",
+      expect.objectContaining({
+        message: expect.not.stringContaining("very-secret-refresh-token"),
+      }),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "OneDrive OAuth token exchange failed.",
+      expect.objectContaining({
+        message: expect.stringContaining("[REDACTED]"),
+      }),
+    );
+    errorSpy.mockRestore();
   });
 
   it("Redis障害時は503で停止する", async () => {

--- a/app/routes/auth.onedrive.callback.tsx
+++ b/app/routes/auth.onedrive.callback.tsx
@@ -7,6 +7,7 @@
 import { redirect } from "react-router";
 import { isHttpsRequest } from "../services/https-validation.server";
 import { logger } from "../services/logger.server";
+import { buildOneDriveAuditErrorPayload, sanitizeAuditPayload } from "../services/onedrive-audit-log.server";
 import {
   ensureOAuthSessionStoreAvailable,
   isOAuthSessionTokenCryptoError,
@@ -58,11 +59,17 @@ export async function loader({ request }: { request: Request }) {
 
   if (error) {
     // 詳細はサーバーログに残し、クライアントには再試行可能な定型メッセージのみ返す。
-    logger.warn("OneDrive OAuth callback returned an error.", {
-      error,
-      errorDescription,
-      errorCodes,
-    });
+    logger.warn(
+      "OneDrive OAuth callback returned an error.",
+      sanitizeAuditPayload({
+        event: "onedrive.oauth-callback-provider-error",
+        route: "auth/onedrive/callback",
+        failureType: "oauth-provider",
+        error,
+        errorDescription,
+        errorCodes,
+      }),
+    );
     return buildOAuthFailureRedirect();
   }
 
@@ -105,9 +112,17 @@ export async function loader({ request }: { request: Request }) {
     await ensureOAuthSessionStoreAvailable();
   } catch (error) {
     if (isOAuthSessionStoreUnavailableError(error)) {
-      logger.error("OneDrive OAuth session store failed.", {
-        message: error.message,
-      });
+      // セッションストアが利用できない場合は、OAuthフローを継続できないため、クライアントには一時的な障害であることを伝える。
+      logger.error(
+        "OneDrive OAuth session store failed.",
+        buildOneDriveAuditErrorPayload({
+          event: "onedrive.session-store-unavailable",
+          route: "auth/onedrive/callback",
+          error,
+          status: 503,
+          failureType: "session-store",
+        }),
+      );
       return new Response(OAUTH_INFRASTRUCTURE_ERROR_MESSAGE, { status: 503 });
     }
     throw error;
@@ -120,14 +135,28 @@ export async function loader({ request }: { request: Request }) {
   } catch (err) {
     // トークン交換失敗の原因がセッションストア障害なのかを判別し、適切なレスポンスを返す。
     if (isOAuthSessionStoreUnavailableError(err)) {
-      logger.error("OneDrive OAuth session store failed.", {
-        message: err.message,
-      });
+      logger.error(
+        "OneDrive OAuth session store failed.",
+        buildOneDriveAuditErrorPayload({
+          event: "onedrive.session-store-unavailable",
+          route: "auth/onedrive/callback",
+          error: err,
+          status: 503,
+          failureType: "session-store",
+        }),
+      );
       return new Response(OAUTH_INFRASTRUCTURE_ERROR_MESSAGE, { status: 503 });
     }
-    const message = err instanceof Error ? err.message : "Unknown error";
     // token交換失敗の詳細はサーバーログのみで扱う。
-    logger.error("OneDrive OAuth token exchange failed.", { message });
+    logger.error(
+      "OneDrive OAuth token exchange failed.",
+      buildOneDriveAuditErrorPayload({
+        event: "onedrive.oauth-token-exchange-failed",
+        route: "auth/onedrive/callback",
+        error: err,
+        failureType: "oauth-token-exchange",
+      }),
+    );
     return buildOAuthFailureRedirect();
   }
   const sessionId = crypto.randomUUID();
@@ -136,17 +165,35 @@ export async function loader({ request }: { request: Request }) {
   } catch (error) {
     // トークン保存失敗の原因がセッションストア障害なのかを判別し、適切なレスポンスを返す。
     if (isOAuthSessionStoreUnavailableError(error)) {
-      logger.error("OneDrive OAuth session store failed.", {
-        message: error.message,
-        errorType: "store-unavailable",
-      });
+      logger.error(
+        "OneDrive OAuth session store failed.",
+        buildOneDriveAuditErrorPayload({
+          event: "onedrive.session-store-unavailable",
+          route: "auth/onedrive/callback",
+          error,
+          status: 503,
+          failureType: "session-store",
+          extra: {
+            errorType: "store-unavailable",
+          },
+        }),
+      );
       return buildOAuthInfrastructureErrorResponse(OAUTH_PERSIST_FAILED_AFTER_EXCHANGE_MESSAGE);
     }
     if (isOAuthSessionTokenCryptoError(error)) {
-      logger.error("OneDrive OAuth token crypto failed.", {
-        message: error.message,
-        errorType: "token-crypto",
-      });
+      logger.error(
+        "OneDrive OAuth token crypto failed.",
+        buildOneDriveAuditErrorPayload({
+          event: "onedrive.token-crypto-failed",
+          route: "auth/onedrive/callback",
+          error,
+          status: 503,
+          failureType: "token-crypto",
+          extra: {
+            errorType: "token-crypto",
+          },
+        }),
+      );
       return buildOAuthInfrastructureErrorResponse(OAUTH_PERSIST_FAILED_AFTER_EXCHANGE_MESSAGE);
     }
     throw error;

--- a/app/routes/auth.onedrive.login.test.ts
+++ b/app/routes/auth.onedrive.login.test.ts
@@ -30,7 +30,7 @@ describe("auth.onedrive.login loader", () => {
     vi.mocked(ensureOAuthSessionStoreAvailable).mockRejectedValue(
       new (class OAuthSessionStoreUnavailableError extends Error {
         constructor() {
-          super("redis down");
+          super("redis down token=super-secret-token");
           this.name = "OAuthSessionStoreUnavailableError";
         }
       })(),
@@ -43,6 +43,18 @@ describe("auth.onedrive.login loader", () => {
     expect(response.status).toBe(503);
     expect(body).toContain("OneDrive 認証基盤で一時障害");
     expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "OneDrive OAuth session store failed.",
+      expect.objectContaining({
+        message: expect.not.stringContaining("super-secret-token"),
+      }),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "OneDrive OAuth session store failed.",
+      expect.objectContaining({
+        message: expect.stringContaining("[REDACTED]"),
+      }),
+    );
     errorSpy.mockRestore();
   });
 });

--- a/app/routes/auth.onedrive.login.tsx
+++ b/app/routes/auth.onedrive.login.tsx
@@ -7,6 +7,7 @@ import { redirect } from "react-router";
 // OneDrive OAuthはセキュアな環境でのみ動作するため、HTTPSでない場合はエラーレスポンスを返す。
 import { isHttpsRequest } from "../services/https-validation.server";
 import { logger } from "../services/logger.server";
+import { buildOneDriveAuditErrorPayload } from "../services/onedrive-audit-log.server";
 import { ensureOAuthSessionStoreAvailable, isOAuthSessionStoreUnavailableError } from "../services/onedrive-oauth-session.server";
 import {
   buildAuthorizeUrl,
@@ -28,9 +29,17 @@ export async function loader({ request }: { request: Request }) {
     await ensureOAuthSessionStoreAvailable();
   } catch (error) {
     if (isOAuthSessionStoreUnavailableError(error)) {
-      logger.error("OneDrive OAuth session store failed.", {
-        message: error.message,
-      });
+      // セッションストアが利用できない場合は、OAuthフローを継続できないため、クライアントには一時的な障害であることを伝える。
+      logger.error(
+        "OneDrive OAuth session store failed.",
+        buildOneDriveAuditErrorPayload({
+          event: "onedrive.session-store-unavailable",
+          route: "auth/onedrive/login",
+          error,
+          status: 503,
+          failureType: "session-store",
+        }),
+      );
       return new Response(
         "OneDrive 認証基盤で一時障害が発生しています。時間をおいて再試行してください。",
         { status: 503 },

--- a/app/services/onedrive-audit-log.server.test.ts
+++ b/app/services/onedrive-audit-log.server.test.ts
@@ -1,0 +1,41 @@
+/**
+ * このファイルを用意した理由:
+ * - OneDrive監査ログのマスキング契約が壊れないように回帰防止するため。
+ *
+ * このファイルが使われる場面:
+ * - ログpayload生成時に token/secret などの機微情報が `[REDACTED]` へ置換されるか検証するとき。
+ */
+import { describe, expect, it } from "vitest";
+import { buildOneDriveAuditErrorPayload, sanitizeAuditPayload } from "./onedrive-audit-log.server";
+
+describe("onedrive-audit-log", () => {
+  it("機微なtoken/secret情報を [REDACTED] に置換する", () => {
+    const payload = buildOneDriveAuditErrorPayload({
+      event: "onedrive.test",
+      route: "api/onedrive/test",
+      failureType: "test",
+      error: new Error(
+        "OneDrive API error (401) [code=InvalidAuthenticationToken]: token=abc123 access_token=xyz secret=foo",
+      ),
+    });
+
+    expect(payload.message).not.toContain("abc123");
+    expect(payload.message).not.toContain("xyz");
+    expect(payload.message).not.toContain("foo");
+    expect(payload.message).toContain("[REDACTED]");
+  });
+
+  it("payload key名が機微情報の場合は値をマスクする", () => {
+    const payload = sanitizeAuditPayload({
+      token: "plain-token",
+      refreshToken: "refresh-token",
+      nested: {
+        authorization: "Bearer abc.def.ghi",
+      },
+    });
+
+    expect(payload.token).toBe("[REDACTED]");
+    expect(payload.refreshToken).toBe("[REDACTED]");
+    expect(payload.nested).toEqual({ authorization: "[REDACTED]" });
+  });
+});

--- a/app/services/onedrive-audit-log.server.test.ts
+++ b/app/services/onedrive-audit-log.server.test.ts
@@ -38,4 +38,16 @@ describe("onedrive-audit-log", () => {
     expect(payload.refreshToken).toBe("[REDACTED]");
     expect(payload.nested).toEqual({ authorization: "[REDACTED]" });
   });
+
+  it("authorization: Bearer 形式の値を完全マスクする", () => {
+    const payload = buildOneDriveAuditErrorPayload({
+      event: "onedrive.test",
+      route: "api/onedrive/test",
+      failureType: "test",
+      error: new Error("authorization: Bearer abc.def=="),
+    });
+
+    expect(payload.message).toBe("authorization: [REDACTED]");
+    expect(payload.message).not.toContain("abc.def==");
+  });
 });

--- a/app/services/onedrive-audit-log.server.ts
+++ b/app/services/onedrive-audit-log.server.ts
@@ -1,0 +1,92 @@
+/**
+ * このファイルを用意した理由:
+ * - OneDrive OAuth/保存系の障害ログを構造化し、機微情報を一貫してマスキングするため。
+ *
+ * このファイルが使われる場面:
+ * - `api.onedrive.upload` / `api.onedrive.archive` / `api.onedrive.evidence-image` /
+ *   `api.onedrive.session-status` / `onedrive-oauth-session` の失敗ログを出力するとき。
+ */
+import { extractOneDriveError } from "./onedrive-errors.server";
+
+const SENSITIVE_KEY_PATTERN = /(token|secret|password|authorization|cookie)/i;
+const REDACTED = "[REDACTED]";
+
+const SENSITIVE_TEXT_PATTERNS = [
+  /([?&](?:access_token|refresh_token|token|client_secret|code)=)[^&\s]+/gi,
+  /((?:access[_-]?token|refresh[_-]?token|token|secret|password|authorization|cookie))\s*[:=]\s*([^\s,;]+)/gi,
+  /\bBearer\s+[A-Za-z0-9._~+\-/]+=*\b/gi,
+  /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+\b/g,
+];
+
+function maskSensitiveText(value: string): string {
+  // URLクエリ/ヘッダー形式/トークン文字列の揺れをまとめてマスクする。
+  let sanitized = value;
+  for (const pattern of SENSITIVE_TEXT_PATTERNS) {
+    sanitized = sanitized.replace(pattern, (match, keyPrefix) => {
+      if (typeof keyPrefix === "string") {
+        return `${keyPrefix}${REDACTED}`;
+      }
+      return REDACTED;
+    });
+  }
+  return sanitized;
+}
+
+function sanitizeAuditValue(value: unknown, depth = 0): unknown {
+  // 深すぎるネストは切り詰めて、循環や巨大payloadでログが肥大化するのを防ぐ。
+  if (depth > 4) return "[TRUNCATED]";
+  if (typeof value === "string") return maskSensitiveText(value);
+  if (typeof value === "number" || typeof value === "boolean" || value === null || value === undefined) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeAuditValue(entry, depth + 1));
+  }
+  if (typeof value === "object") {
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      if (SENSITIVE_KEY_PATTERN.test(key)) {
+        sanitized[key] = REDACTED;
+        continue;
+      }
+      sanitized[key] = sanitizeAuditValue(entry, depth + 1);
+    }
+    return sanitized;
+  }
+  return String(value);
+}
+
+export function sanitizeAuditPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  return sanitizeAuditValue(payload) as Record<string, unknown>;
+}
+
+export function buildOneDriveAuditErrorPayload({
+  event,
+  route,
+  error,
+  status,
+  failureType,
+  extra,
+}: {
+  event: string;
+  route: string;
+  error: unknown;
+  status?: number;
+  failureType: string;
+  extra?: Record<string, unknown>;
+}): Record<string, unknown> {
+  // ルート層で使う監査ログの共通フォーマットをここで固定する。
+  const rawMessage = error instanceof Error ? error.message : String(error);
+  const parsed = extractOneDriveError(rawMessage);
+  return sanitizeAuditPayload({
+    event,
+    route,
+    failureType,
+    status: status ?? null,
+    errorName: error instanceof Error ? error.name : typeof error,
+    message: rawMessage,
+    code: parsed.code ?? null,
+    detail: parsed.message ?? null,
+    ...(extra ?? {}),
+  });
+}

--- a/app/services/onedrive-audit-log.server.ts
+++ b/app/services/onedrive-audit-log.server.ts
@@ -13,8 +13,8 @@ const REDACTED = "[REDACTED]";
 
 const SENSITIVE_TEXT_PATTERNS = [
   /([?&](?:access_token|refresh_token|token|client_secret|code)=)[^&\s]+/gi,
-  /((?:access[_-]?token|refresh[_-]?token|token|secret|password|authorization|cookie))\s*[:=]\s*([^\s,;]+)/gi,
   /\bBearer\s+[A-Za-z0-9._~+\-/]+=*\b/gi,
+  /((?:access[_-]?token|refresh[_-]?token|token|secret|password|authorization|cookie)\s*[:=]\s*)([^\s,;]+)/gi,
   /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+\b/g,
 ];
 

--- a/app/services/onedrive-errors.server.test.ts
+++ b/app/services/onedrive-errors.server.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractOneDriveError, isOneDriveAuthLikeError } from "./onedrive-errors.server";
+import { extractOneDriveError, isOneDriveAuthLikeError, resolveOneDriveAuthStatus } from "./onedrive-errors.server";
 
 describe("onedrive-errors", () => {
   it("extractOneDriveError は message 末尾の request-id メタを除去する", () => {
@@ -30,5 +30,20 @@ describe("onedrive-errors", () => {
   it("isOneDriveAuthLikeError は token crypto エラーを認証エラー扱いしない", () => {
     const raw = "OneDrive token crypto encrypt failed: cipher failed";
     expect(isOneDriveAuthLikeError(raw)).toBe(false);
+  });
+
+  it("resolveOneDriveAuthStatus は code=AccessDenied を 403 に正規化する", () => {
+    const raw = "OneDrive API error (401) [code=AccessDenied]: forbidden";
+    expect(resolveOneDriveAuthStatus(raw, "AccessDenied")).toBe(403);
+  });
+
+  it("resolveOneDriveAuthStatus は code 不在でも (403) を優先して 403 にする", () => {
+    const raw = "OneDrive API error (403): forbidden";
+    expect(resolveOneDriveAuthStatus(raw, undefined)).toBe(403);
+  });
+
+  it("resolveOneDriveAuthStatus は 403 根拠がない場合 401 にする", () => {
+    const raw = "OneDrive API error (401): token expired";
+    expect(resolveOneDriveAuthStatus(raw, undefined)).toBe(401);
   });
 });

--- a/app/services/onedrive-errors.server.ts
+++ b/app/services/onedrive-errors.server.ts
@@ -33,3 +33,10 @@ export function isOneDriveAuthLikeError(rawMessage: string): boolean {
     message.includes("[code=accessdenied]")
   );
 }
+
+// auth-like エラーの HTTP ステータスを 401/403 に正規化する。
+export function resolveOneDriveAuthStatus(rawMessage: string, code?: string): 401 | 403 {
+  if (code?.toLowerCase() === "accessdenied") return 403;
+  if (/onedrive api error \(403\)/i.test(rawMessage)) return 403;
+  return 401;
+}

--- a/app/services/onedrive-oauth-session.server.ts
+++ b/app/services/onedrive-oauth-session.server.ts
@@ -14,6 +14,7 @@ import { redisCompareAndDelete, redisDel, redisGet, redisSetEx, redisSetNxPx } f
 import { createCipheriv, createDecipheriv, createHash, hkdfSync, randomBytes } from "node:crypto";
 import { resolvedSessionSecret } from "./session-secret.server";
 import { logger } from "./logger.server";
+import { sanitizeAuditPayload } from "./onedrive-audit-log.server";
 
 // 定数定義。呼び出し側はこれらの値を知らなくていいように、必要なロジックはこのファイル内に閉じ込める。
 const SESSION_TTL_SECONDS = 60 * 60 * 24 * 7;
@@ -93,7 +94,11 @@ function resolveTokenEncryptionKeys(): { current: TokenEncryptionKey; previous: 
         );
       }
       logger.warn("OneDrive token encryption rotation proceeds without previous key; existing sessions may be invalidated.", {
-        currentKeyVersion: TOKEN_ENCRYPTION_CURRENT_KEY_VERSION,
+        ...sanitizeAuditPayload({
+          event: "onedrive.rotation-without-previous-key",
+          route: "onedrive-oauth-session",
+          currentKeyVersion: TOKEN_ENCRYPTION_CURRENT_KEY_VERSION,
+        }),
       });
     }
     return { current, previous: null };
@@ -244,6 +249,7 @@ type DecryptTokenCacheResult =
   | { cache: null; reason: string; cause?: string };
 
 function classifyDecryptFailureCause(error: unknown): string {
+  // OpenSSL 由来の例外文言ゆれを、運用で集計しやすい固定コードへ寄せる。
   if (!(error instanceof Error)) return "unexpected-error";
   const message = error.message.toLowerCase();
   if (message.includes("authenticate") || message.includes("auth tag")) {
@@ -261,6 +267,7 @@ function decryptTokenCacheWithKey(
   ciphertextSegment: string,
   key: Buffer,
 ): ParseTokenCacheResult {
+  // セグメント境界チェックを先に行い、復号処理へ不正データを渡さない。
   const iv = Buffer.from(ivSegment, "base64url");
   const authTag = Buffer.from(authTagSegment, "base64url");
   const encrypted = Buffer.from(ciphertextSegment, "base64url");
@@ -274,6 +281,7 @@ function decryptTokenCacheWithKey(
 }
 
 function resolveKeyByVersion(version: string): TokenEncryptionKey | null {
+  // 5-segment 形式は keyVersion 指定の鍵だけを使い、総当たり復号はしない。
   if (version === tokenEncryptionKeys.current.version) return tokenEncryptionKeys.current;
   if (tokenEncryptionKeys.previous && version === tokenEncryptionKeys.previous.version) return tokenEncryptionKeys.previous;
   return null;
@@ -283,6 +291,7 @@ function resolveKeyByVersion(version: string): TokenEncryptionKey | null {
 function decryptTokenCache(value: string): DecryptTokenCacheResult {
   const segments = value.split(".");
   if (segments.length === 5) {
+    // 新形式は keyVersion 固定で1鍵のみ試行し、復号不能は fail-closed。
     if (segments[0] !== TOKEN_ENCRYPTION_VERSION_PREFIX) return { cache: null, reason: "unknown-version" };
     const keyVersion = segments[1] ?? "";
     const keyEntry = resolveKeyByVersion(keyVersion);
@@ -296,6 +305,7 @@ function decryptTokenCache(value: string): DecryptTokenCacheResult {
   }
 
   if (segments.length === 4) {
+    // 旧形式のみ後方互換のために順序付きフォールバックを許可する。
     if (segments[0] !== TOKEN_ENCRYPTION_VERSION_PREFIX) return { cache: null, reason: "unknown-version" };
     const keysToTry = [
       tokenEncryptionKeys.current.key,
@@ -372,9 +382,13 @@ export async function getTokenForSession(sessionId: string | null): Promise<Toke
   const decrypted = decryptTokenCache(raw);
   if (!decrypted.cache) {
     logger.warn("Discarding invalid OneDrive OAuth session token.", {
-      sessionIdHash: toSessionIdLogHash(sessionId),
-      reason: decrypted.reason,
-      ...(decrypted.cause ? { cause: decrypted.cause } : {}),
+      ...sanitizeAuditPayload({
+        event: "onedrive.invalid-session-token-discarded",
+        route: "onedrive-oauth-session",
+        sessionIdHash: toSessionIdLogHash(sessionId),
+        reason: decrypted.reason,
+        ...(decrypted.cause ? { cause: decrypted.cause } : {}),
+      }),
     });
     await deleteCorruptedSessionKey(sessionId);
     return null;

--- a/docs/onedrive-oauth-key-rotation-runbook.md
+++ b/docs/onedrive-oauth-key-rotation-runbook.md
@@ -37,6 +37,30 @@
 - ロールバック判断時は「OneDrive 再認証が必要になる可能性」を前提情報として扱う。
 - 必要なら影響時間帯を限定し、ユーザー告知を先行する。
 
+## 監査ログ運用（Issue #45）
+- 目的: 障害調査に必要な相関情報を残しつつ、token/secret/PII の露出を防ぐ。
+- 共通ログ項目:
+  - `event`（失敗種別）
+  - `route`（どの API で発生したか）
+  - `failureType`（`session-store` / `onedrive-auth` / `onedrive-non-auth` など）
+  - `status`（返却HTTPステータス）
+  - `errorName` / `code`
+  - `message` / `detail`（機微値は `[REDACTED]` へマスク）
+
+### 主要失敗パターンのログ例
+- 認証系（401/403）
+  - `event=onedrive.auth-failure`, `route=api/onedrive/upload`, `status=401`, `code=InvalidAuthenticationToken`
+- レート制限（429）
+  - `event=onedrive.evidence-image-fetch-failed`, `route=api/onedrive/evidence-image`, `status=429`
+- セッションストア障害（503）
+  - `event=onedrive.session-store-unavailable`, `failureType=session-store`, `status=503`
+- 復号失敗（fail-closed）
+  - `event=onedrive.invalid-session-token-discarded`, `route=onedrive-oauth-session`, `reason=decrypt-failed`, `sessionIdHash=<hash>`
+
+### 禁止事項
+- `accessToken` / `refreshToken` / `secret` / `authorization` の平文出力
+- sessionId の平文出力（`sessionIdHash` を使用）
+
 ## 意図的な全セッション失効が必要な場合
 1. `ONEDRIVE_TOKEN_ENCRYPTION_ALLOW_SESSION_INVALIDATION=true` を明示設定する。
 2. 失効の目的と実施時刻を運用記録に残す。


### PR DESCRIPTION
## Summary（必須）
- 何を変えたか:
  - Issue #45 対応として、OneDrive OAuth/保存系の監査ログを構造化・マスキング統一しました。
  - 新規 `app/services/onedrive-audit-log.server.ts` を追加し、機微情報（token/secret/authorization/cookie 等）の `[REDACTED]` 化を共通化しました。
  - 以下ルートの失敗ログを共通フォーマット（`event/route/failureType/status/errorName/code/detail`）へ寄せました。
    - `/api/onedrive/upload`
    - `/api/onedrive/archive`
    - `/api/onedrive/evidence-image`
    - `/api/onedrive/session-status`
    - `/auth/onedrive/login`
    - `/auth/onedrive/callback`
  - `401/403` の観測一貫性を改善し、`accessDenied` は `403`、認証失効は `401` として扱いを統一しました（`isAuthError` は `401` のみ `true`）。
  - 429（rate limit）時の監査ログを `evidence-image` に追加しました。
  - runbook/requirements に監査ログ運用要件を追記しました。
- なぜ（背景/狙い）:
  - 障害調査に必要な相関情報を残しつつ、トークンや秘密情報の平文露出を防ぐため。
  - ルート間で異なっていた `401/403` 判定を統一し、運用観測とUI分岐の一貫性を上げるため。
- Touch / Do NOT touch:
  - Touch:
    - `app/services/onedrive-audit-log.server.ts`
    - `app/services/onedrive-audit-log.server.test.ts`
    - `app/services/onedrive-oauth-session.server.ts`
    - `app/routes/api.onedrive.upload.tsx`
    - `app/routes/api.onedrive.archive.tsx`
    - `app/routes/api.onedrive.evidence-image.tsx`
    - `app/routes/api.onedrive.session-status.tsx`
    - `app/routes/auth.onedrive.login.tsx`
    - `app/routes/auth.onedrive.callback.tsx`
    - 各対応テスト
    - `docs/onedrive-oauth-key-rotation-runbook.md`
    - `REQUIREMENTS.md`
  - Do NOT touch:
    - OAuthフロー本体仕様（認証導線・外部契約の大枠）
    - 依存追加/ビルド設定変更

## Acceptance（Must）（必須）
- [x] ログに token/secret 等の機微値が平文出力されない
- [x] 障害調査に必要な構造化ログ項目（event/route/failureType/status/code 等）が残る
- [x] 主要失敗パターン（401/403/429/5xx/Redis障害/復号失敗）の観測一貫性を確保
- [x] `accessDenied` を `403` として扱い、`401` と区別できる

## Invariants（必須）
- OneDrive session store 障害は `503` として扱う
- token crypto 障害は認証エラーと混同しない
- auth-like 判定でも `accessDenied` は `403` を維持する
- `isAuthError` は再認証導線（401）のみ `true` とする

## Deferred / Non-goals（任意）
- 外部SIEM連携の新規導入
- OAuth機能仕様の拡張（新規フロー追加）

## Validation（必須）
- Commands to run（提案）:
  - [x] `npm run -s lint`
  - [x] `npm run -s typecheck`
  - [x] `npm run -s test`
  - [x] `npm run -s build`
- Commands run（Human）:
  - `npm run -s lint && npm run -s typecheck && npm run -s test && npm run -s build` ✅
- Smoke check（UI/手動が必要な場合のみ）:
  - [ ] 未実施（今回はルート/サービス層のログ契約とエラーハンドリング中心）

## Evidence（必須）
- Logs:
  - `lint` → ✅（error 0 / warning 1: 既存 `app/services/redis.server.test.ts` の `no-explicit-any`）
  - `typecheck` → ✅
  - `test` → ✅（26 files / 240 tests）
  - `build` → ✅
- Screenshots:
  - Image 1: N/A
  - Image 2: N/A

## Contracts changed（変更がある場合）
- API:
  - `/api/onedrive/upload`: auth-like時に `accessDenied` を `403` で返却
  - `/api/onedrive/archive`: auth-like時に `accessDenied` を `403` で返却
  - `/api/onedrive/session-status`: auth-like時に `accessDenied` を `403` で返却
- DB / migration:
  - なし
- Events / jobs:
  - なし
- Types / schemas:
  - なし（レスポンス型は既存フィールドを維持）

## Security / Trust Boundary（変更がある場合）
- 認証:
  - `401`（認証失効）と `403`（権限不足）を明確に分離
- 認可:
  - `accessDenied` は `403` で返却・監査ログ化
- 外部入力:
  - OAuth provider error / OneDrive API error 由来文字列をログ出力前にサニタイズ
- 機微情報（PII / secrets / logs）:
  - token/secret/authorization/cookie を `[REDACTED]` 化して記録

## Risk / Rollback（大きい変更は必須）
- 影響範囲:
  - OneDrive関連ルートのエラーログ出力形式
  - `401/403` のステータス判定
- 失敗時の戻し方:
  - 本PRをrevertすれば元のログ形式/判定へ戻せる（可逆）
- 互換性:
  - 既存APIレスポンス構造は維持（ステータス分岐の精度のみ改善）

## Links（任意）
- Issue:
  - #45
- PR:
  - （このPR）
