### PR TITLE
Issue 41 compose nonroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,36 @@ Notes:
 - ブラウザでの実運用確認や OneDrive OAuth は、HTTPS 終端された入口（Nginx / ingress / load balancer）配下で行ってください。
 - コンテナには `/api/health` を見る `HEALTHCHECK` を設定しています。
 
+### Docker Compose (app + redis + nginx HTTPS)
+
+`compose.yaml` で app / redis / nginx(https) を一括起動できます。
+
+```bash
+docker compose up -d --build
+```
+
+`5173` が使用中の場合は公開ポートを変更できます。
+
+```bash
+COMPOSE_PUBLIC_PORT=15173 docker compose up -d --build
+```
+
+`SESSION_SECRET` は compose でも必要です。未指定時は開発用デフォルト値が使われます。
+
+疎通確認:
+
+```bash
+curl -k https://localhost:${COMPOSE_PUBLIC_PORT:-5173}/api/health
+```
+
+`app` が non-root で動作していることの確認:
+
+```bash
+docker compose exec app id -u
+```
+
+`0` 以外であれば non-root 実行です。
+
 The containerized application can be deployed to any platform that supports Docker, including:
 
 - AWS ECS

--- a/README.md
+++ b/README.md
@@ -154,16 +154,17 @@ Notes:
 `compose.yaml` で app / redis / nginx(https) を一括起動できます。
 
 ```bash
-docker compose up -d --build
+SESSION_SECRET='change-me-long-random-secret' docker compose up -d --build
 ```
 
 `5173` が使用中の場合は公開ポートを変更できます。
 
 ```bash
-COMPOSE_PUBLIC_PORT=15173 docker compose up -d --build
+SESSION_SECRET='change-me-long-random-secret' COMPOSE_PUBLIC_PORT=15173 docker compose up -d --build
 ```
 
-`SESSION_SECRET` は compose でも必要です。未指定時は開発用デフォルト値が使われます。
+`SESSION_SECRET` は compose でも必須です。未指定なら起動を停止します。
+公開ポートは loopback (`127.0.0.1`) のみに bind するため、ローカル開発用途を前提にしています。
 
 疎通確認:
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -133,10 +133,10 @@
    - OAuth の `state` およびブラウザ整合性確認用の短期値は、署名付き Secure Cookie で保持してよい。Redis 保存は必須としない。
    - CSRF 対策は署名付き Secure Cookie を用いた方式を維持してよく、Redis 保存は必須としない。
    - OneDrive OAuth を利用するすべての外部公開経路は HTTPS を必須とし、HTTP では認証フローを開始・完了させない。
-   - `SESSION_SECRET` は production で必須とし、Cookie 署名の信頼境界を維持する。
+   - `SESSION_SECRET` は production で必須とし、未設定時は起動を fail-fast で停止する。開発用途の固定デフォルト値フォールバックは非production環境に限定し、production で許可してはならない。
    - Redis に保存する OneDrive OAuth の `accessToken` / `refreshToken` を平文で保存してはならない。保存時はサーバー側で暗号化し、読み取り時に復号して利用する。
    - Redis 上の token 保存形式はバージョン識別子を先頭に含むこと（例: `v1.<keyVersion>.<iv>.<authTag>.<ciphertext>`）。未対応バージョンや不正形式は fail-closed で無効セッションとして扱う。
-   - token 暗号化鍵は鍵素材設定（`ONEDRIVE_TOKEN_ENCRYPTION_CURRENT_KEY_MATERIAL` / `ONEDRIVE_TOKEN_ENCRYPTION_PREVIOUS_KEY_MATERIAL`）から導出すること。これらが未設定の場合は `SESSION_SECRET` をデフォルト鍵素材として利用すること。
+   - token 暗号化鍵は鍵素材設定（`ONEDRIVE_TOKEN_ENCRYPTION_CURRENT_KEY_MATERIAL` / `ONEDRIVE_TOKEN_ENCRYPTION_PREVIOUS_KEY_MATERIAL`）から導出すること。これらが未設定の場合は `SESSION_SECRET` をデフォルト鍵素材として利用する。環境変数が定義済みで空文字（空白のみ含む）だった場合は設定ミスとして fail-fast で停止すること。
    - 鍵ローテーションは `current + previous(1世代)` を上限とする。`previous` は未設定可だが、複数世代（2世代以上）の同時サポートは要件外とする。
    - 新規保存時の暗号化は常に `current` 鍵を使用し、`previous` 鍵で新規暗号化してはならない。
    - 復号時の鍵選択は token 形式に応じて行うこと。5-segment 形式（例: `v1.<keyVersion>.<iv>.<authTag>.<ciphertext>`）では `keyVersion` に基づき `current` または `previous` のいずれか 1 つの鍵のみで復号を試行し、復号失敗または unknown key version の場合は fail-closed で無効セッション扱いとする。4-segment など旧形式 token は `current` → `previous` → legacy(sha256) の順で復号を試行し、いずれも復号不能な場合は fail-closed で無効セッション扱いとする。

--- a/app/services/https-validation.server.test.ts
+++ b/app/services/https-validation.server.test.ts
@@ -1,0 +1,76 @@
+/**
+ * HTTPS判定ユーティリティの回帰テスト
+ *
+ * このファイルを作った理由:
+ * - nginx などの HTTPS 終端プロキシ配下で、公開側 host:port を正しく引き継がないと
+ *   OneDrive OAuth が 400 で失敗する経路を固定するため。
+ *
+ * このファイルが使われる場面:
+ * - proxy ヘッダーや trusted host 判定を変更したとき。
+ * - compose / nginx 設定変更で OneDrive OAuth の HTTPS 判定互換性を確認したいとき。
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { isHttpsRequest } from "./https-validation.server";
+
+type EnvSnapshot = Record<string, string | undefined>;
+
+const ENV_KEYS = [
+  "ONEDRIVE_TRUST_X_FORWARDED_PROTO",
+  "ONEDRIVE_TRUSTED_PROXY_HOSTS",
+  "ONEDRIVE_TRUST_PROXY_SHARED_SECRET",
+] as const;
+
+// HTTPS 判定に影響する env だけを退避し、他テストへのリークを防ぐ。
+function snapshotEnv(): EnvSnapshot {
+  return Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+}
+
+// undefined は削除、それ以外は復元して import 時の設定差分を残さない。
+function restoreEnv(snapshot: EnvSnapshot): void {
+  for (const key of ENV_KEYS) {
+    const value = snapshot[key];
+    if (value === undefined) {
+      delete process.env[key];
+      continue;
+    }
+    process.env[key] = value;
+  }
+}
+
+describe("isHttpsRequest", () => {
+  const originalEnv = snapshotEnv();
+
+  afterEach(() => {
+    restoreEnv(originalEnv);
+  });
+
+  it("プロキシが公開 host:port を保持していれば HTTPS と判定する", () => {
+    process.env.ONEDRIVE_TRUST_X_FORWARDED_PROTO = "true";
+    process.env.ONEDRIVE_TRUSTED_PROXY_HOSTS = "localhost:15173";
+
+    const request = new Request("http://app:3000/auth/onedrive/login", {
+      headers: {
+        host: "localhost:15173",
+        "x-forwarded-host": "localhost:15173",
+        "x-forwarded-proto": "https",
+      },
+    });
+
+    expect(isHttpsRequest(request)).toBe(true);
+  });
+
+  it("プロキシが内部 listen port を渡すと trusted host と一致せず拒否する", () => {
+    process.env.ONEDRIVE_TRUST_X_FORWARDED_PROTO = "true";
+    process.env.ONEDRIVE_TRUSTED_PROXY_HOSTS = "localhost:15173";
+
+    const request = new Request("http://app:3000/auth/onedrive/login", {
+      headers: {
+        host: "localhost:443",
+        "x-forwarded-host": "localhost:443",
+        "x-forwarded-proto": "https",
+      },
+    });
+
+    expect(isHttpsRequest(request)).toBe(false);
+  });
+});

--- a/compose.yaml
+++ b/compose.yaml
@@ -59,7 +59,7 @@ services:
       certgen:
         condition: service_completed_successfully
       app:
-        condition: service_started
+        condition: service_healthy
 
 volumes:
   redis-data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,66 @@
+services:
+  certgen:
+    image: alpine:3.20
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        apk add --no-cache openssl >/dev/null
+        mkdir -p /certs
+        if [ ! -f /certs/dev.crt ] || [ ! -f /certs/dev.key ]; then
+          openssl req -x509 -nodes -newkey rsa:2048 \
+            -keyout /certs/dev.key \
+            -out /certs/dev.crt \
+            -days 3650 \
+            -subj "/CN=localhost" \
+            -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+        fi
+    volumes:
+      - nginx-certs:/certs
+    restart: "no"
+
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--save", "60", "1", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      NODE_ENV: production
+      PORT: "3000"
+      SESSION_SECRET: ${SESSION_SECRET:-dev-compose-session-secret-change-me}
+      REDIS_URL: redis://redis:6379/0
+      ONEDRIVE_TRUST_X_FORWARDED_PROTO: "true"
+      ONEDRIVE_TRUSTED_PROXY_HOSTS: localhost:${COMPOSE_PUBLIC_PORT:-5173}
+    user: "node"
+    expose:
+      - "3000"
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  nginx:
+    image: nginx:1.27-alpine
+    ports:
+      - "${COMPOSE_PUBLIC_PORT:-5173}:443"
+    volumes:
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - nginx-certs:/certs:ro
+    depends_on:
+      certgen:
+        condition: service_completed_successfully
+      app:
+        condition: service_started
+
+volumes:
+  redis-data:
+  nginx-certs:

--- a/compose.yaml
+++ b/compose.yaml
@@ -37,10 +37,10 @@ services:
     environment:
       NODE_ENV: production
       PORT: "3000"
-      SESSION_SECRET: ${SESSION_SECRET:-dev-compose-session-secret-change-me}
+      SESSION_SECRET: ${SESSION_SECRET:?SESSION_SECRET is required for docker compose}
       REDIS_URL: redis://redis:6379/0
       ONEDRIVE_TRUST_X_FORWARDED_PROTO: "true"
-      ONEDRIVE_TRUSTED_PROXY_HOSTS: localhost:${COMPOSE_PUBLIC_PORT:-5173}
+      ONEDRIVE_TRUSTED_PROXY_HOSTS: localhost:${COMPOSE_PUBLIC_PORT:-5173},127.0.0.1:${COMPOSE_PUBLIC_PORT:-5173}
     user: "node"
     expose:
       - "3000"
@@ -51,7 +51,7 @@ services:
   nginx:
     image: nginx:1.27-alpine
     ports:
-      - "${COMPOSE_PUBLIC_PORT:-5173}:443"
+      - "127.0.0.1:${COMPOSE_PUBLIC_PORT:-5173}:443"
     volumes:
       - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
       - nginx-certs:/certs:ro

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -15,8 +15,9 @@ server {
     location / {
         proxy_pass http://app:3000;
         proxy_http_version 1.1;
-        proxy_set_header Host $host:$server_port;
-        proxy_set_header X-Forwarded-Host $host:$server_port;
+        # 公開側の host:port をそのまま upstream に渡し、OAuth の HTTPS 判定と整合させる。
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,24 @@
+server {
+    listen 80;
+    server_name localhost 127.0.0.1;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name localhost 127.0.0.1;
+
+    ssl_certificate /certs/dev.crt;
+    ssl_certificate_key /certs/dev.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    location / {
+        proxy_pass http://app:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host:$server_port;
+        proxy_set_header X-Forwarded-Host $host:$server_port;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}


### PR DESCRIPTION
## Summary（必須）
- 何を変えたか:
  - `compose.yaml` を追加し、`app + redis + nginx(HTTPS)` のローカル起動構成を導入
  - `docker/nginx/default.conf` を追加し、TLS 終端と upstream への proxy header を定義
  - `SESSION_SECRET` を compose 起動時の必須値に変更（未設定/空文字は fail-fast）
  - `isHttpsRequest` の proxy host 整合に関する回帰テストを追加
  - `README.md` と `REQUIREMENTS.md` を実装仕様に合わせて更新
- なぜ（背景/狙い）:
  - OneDrive OAuth の HTTPS 前提をローカル compose 構成でも満たすため
  - 既知デフォルト secret で production モードが起動するリスクを防ぐため
  - proxy 越しの Host/Forwarded-Host 不整合で OAuth が 400 になる回帰を防ぐため
- Touch / Do NOT touch:
  - Touch:
    - `compose.yaml`
    - `docker/nginx/default.conf`
    - `app/services/https-validation.server.test.ts`
    - `README.md`
    - `REQUIREMENTS.md`
  - Do NOT touch:
    - OneDrive OAuth 本体ロジック（`app/routes/**`, `app/services/onedrive-*.ts` の挙動変更）
    - DB / migration / external API contract

## Acceptance（Must）（必須）
- [x] compose 起動時に `SESSION_SECRET` が未設定または空文字なら起動失敗する
- [x] proxy 経由時、公開側 `host:port` を維持したヘッダーで HTTPS 判定が通る
- [x] loopback bind でローカル開発前提の公開面に制限される
- [x] L0/L1（lint/type/test/build）が通る

## Invariants（必須）
- OneDrive OAuth の HTTPS 要件は維持する（HTTP では認証フローを成立させない）
- production 相当起動で `SESSION_SECRET` の fail-fast を維持する
- 既存 API のレスポンス契約は変更しない

## Deferred / Non-goals（任意）
- 既存 lint warning（`app/services/redis.server.test.ts` の `any`）解消は本 PR 範囲外
- compose の E2E 自動テスト化は本 PR 範囲外（手動/構成検証まで）

## Validation（必須）
- Commands to run（提案）:
  - [x] `npm run lint`
  - [x] `npm run typecheck`
  - [x] `npm test`
  - [x] `npm run build`
  - [x] `SESSION_SECRET=test-compose-secret docker compose config`
  - [x] `SESSION_SECRET='' docker compose config`
- Commands run（Human）:
  - `npm run lint` ✅（warning 1件: `app/services/redis.server.test.ts`）
  - `npm run typecheck` ✅
  - `npm test` ✅（27 files / 246 tests）
  - `npm run build` ✅
